### PR TITLE
Fix issue when changing participant in create new indicator screen

### DIFF
--- a/app/components/CreateNewIndicator/CreateNewIndicatorContent.js
+++ b/app/components/CreateNewIndicator/CreateNewIndicatorContent.js
@@ -1,0 +1,87 @@
+import React, { Component } from 'react';
+import { View, Text } from 'react-native';
+
+import Color from '../../themes/color';
+import { LocalizationContext } from '../Translations';
+import CreateNewIndicatorParticipantInfo from './CreateNewIndicatorParticipantInfo';
+import CriteriaSelection from '../RaisingProposed/CriteriaSelection';
+import RaisingProposedCustomIndicatorList from '../RaisingProposed/RaisingProposedCustomIndicatorList';
+
+import IndicatorService from '../../services/indicator_service';
+import { getDeviceStyle, mobileSubTitleSize } from '../../utils/responsive_util';
+
+const headerTitleSize = getDeviceStyle(18, mobileSubTitleSize());
+
+class CreateNewIndicatorContent extends Component {
+  static contextType = LocalizationContext;
+
+  updateSelectedParticipant(participantUuid) {
+    const { translations } = this.context;
+    const indicatorAttrs = new IndicatorService().getIndicatorList(this.props.scorecardUuid, '', translations.addNewCriteria, []);
+    const dataset = {
+      indicators: indicatorAttrs.indicators,
+      selected_indicators: indicatorAttrs.selectedIndicators,
+      participant_uuid: participantUuid
+    };
+
+    !!this.props.updateSelectedParticipant && this.props.updateSelectedParticipant(dataset);
+  }
+
+  renderParticipant() {
+    if (this.props.isSearching || this.props.isEdit)
+      return;
+
+    return (
+      <CreateNewIndicatorParticipantInfo
+        scorecardUuid={this.props.scorecardUuid}
+        participantUuid={this.props.participantUuid}
+        navigation={this.props.navigation}
+        updateSelectedParticipant={(participantUuid) => this.updateSelectedParticipant(participantUuid)}
+      />
+    )
+  }
+
+  renderCriteriaList() {
+    return (
+      <CriteriaSelection
+        selectIndicator={this.props.selectIndicator}
+        scorecardUuid={this.props.scorecardUuid}
+        participantUuid={this.props.participantUuid}
+        indicators={this.props.indicators}
+        selectedIndicators={this.props.selectedIndicators}
+        unselectedIndicators={this.props.unselectedIndicators}
+        customIndicator={this.props.customIndicator}
+        isSearching={this.props.isSearching}
+      />
+    )
+  }
+
+  renderCustomIndicatorList() {
+    return (
+      <RaisingProposedCustomIndicatorList
+        scorecardUuid={this.props.scorecardUuid}
+        indicators={this.props.indicators}
+        editCustomIndicator={this.props.editCustomIndicator}
+        selectedCustomIndicator={this.props.selectedCustomIndicator}
+      />
+    )
+  }
+
+  render() {
+    return (
+      <View style={{flex: 1}}>
+        { this.renderParticipant() }
+
+        { (!this.props.isSearching && !this.props.isEdit) &&
+          <Text style={{fontSize: headerTitleSize, color: Color.lightBlackColor, marginTop: 20}}>
+            {this.context.translations['chooseProposedCriteria']}
+          </Text>
+        }
+
+        { !this.props.isEdit ? this.renderCriteriaList() : this.renderCustomIndicatorList() }
+      </View>
+    )
+  }
+}
+
+export default CreateNewIndicatorContent;

--- a/app/components/CreateNewIndicator/CreateNewIndicatorParticipantInfo.js
+++ b/app/components/CreateNewIndicator/CreateNewIndicatorParticipantInfo.js
@@ -10,12 +10,8 @@ const headerTitleSize = getDeviceStyle(18, mobileSubTitleSize());
 
 class CreateNewIndicatorParticipantInfo extends Component {
   static contextType = LocalizationContext;
-  state = {
-    participantUuid: this.props.participantUuid
-  }
 
   onUpdateParticipant(participantUuid) {
-    this.setState({ participantUuid });
     !!this.props.updateSelectedParticipant && this.props.updateSelectedParticipant(participantUuid);
   }
 
@@ -29,8 +25,7 @@ class CreateNewIndicatorParticipantInfo extends Component {
         <ParticipantInfo
           participants={Participant.getNotRaised(this.props.scorecardUuid)}
           scorecard_uuid={ this.props.scorecardUuid }
-          participant_uuid={this.state.participantUuid}
-          onGetParticipant={this.props.onGetParticipant}
+          participant_uuid={ this.props.participantUuid }
           navigation={this.props.navigation}
           buttonVisible={false}
           onPressItem={(participant) => this.onUpdateParticipant(participant.uuid)}

--- a/app/components/CreateNewIndicator/CreateNewIndicatorParticipantInfo.js
+++ b/app/components/CreateNewIndicator/CreateNewIndicatorParticipantInfo.js
@@ -10,6 +10,14 @@ const headerTitleSize = getDeviceStyle(18, mobileSubTitleSize());
 
 class CreateNewIndicatorParticipantInfo extends Component {
   static contextType = LocalizationContext;
+  state = {
+    participantUuid: this.props.participantUuid
+  }
+
+  onUpdateParticipant(participantUuid) {
+    this.setState({ participantUuid });
+    !!this.props.updateSelectedParticipant && this.props.updateSelectedParticipant(participantUuid);
+  }
 
   render() {
     return (
@@ -21,10 +29,12 @@ class CreateNewIndicatorParticipantInfo extends Component {
         <ParticipantInfo
           participants={Participant.getNotRaised(this.props.scorecardUuid)}
           scorecard_uuid={ this.props.scorecardUuid }
-          participant_uuid={ this.props.participantUuid }
+          participant_uuid={this.state.participantUuid}
           onGetParticipant={this.props.onGetParticipant}
           navigation={this.props.navigation}
           buttonVisible={false}
+          onPressItem={(participant) => this.onUpdateParticipant(participant.uuid)}
+          onPressCreateParticipant={(participant) => this.onUpdateParticipant(participant.uuid)}
         />
       </View>
     )

--- a/app/components/CreateNewIndicator/CreateNewIndicatorSaveButton.js
+++ b/app/components/CreateNewIndicator/CreateNewIndicatorSaveButton.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import { View } from 'react-native';
+
+import { LocalizationContext } from '../Translations';
+import BottomButton from '../BottomButton';
+import { containerPadding } from '../../utils/responsive_util';
+
+class CreateNewIndicatorSaveButton extends Component {
+  static contextType = LocalizationContext;
+
+  render() {
+    if (this.props.isSearching || this.props.isEdit)
+      return <View/>;
+
+    return (
+      <View style={{padding: containerPadding, paddingHorizontal: 0}}>
+        <BottomButton disabled={!this.props.isValid}
+          label={this.context.translations['saveAndGoNext']}
+          onPress={() => this.props.save()}
+        />
+      </View>
+    )
+  }
+}
+
+export default CreateNewIndicatorSaveButton;

--- a/app/components/CreateNewIndicator/ParticipantInfo.js
+++ b/app/components/CreateNewIndicator/ParticipantInfo.js
@@ -1,13 +1,12 @@
 import React, {Component} from 'react';
 import { View } from 'react-native';
 
-import realm from '../../db/schema';
 import { LocalizationContext } from '../../components/Translations';
-
 import ParticipantModal from '../../components/RaisingProposed/ParticipantModal';
 import AddNewParticiantModal from '../../components/RaisingProposed/AddNewParticipantModal';
 import ParticipantModalListItem from '../../components/RaisingProposed/ParticipantModalListItem';
 import OutlinedButton from '../OutlinedButton';
+import Participant from '../../models/Participant';
 
 export default class ParticipantInfo extends Component {
   static contextType = LocalizationContext;
@@ -19,13 +18,21 @@ export default class ParticipantInfo extends Component {
       participants: props.participants || [],
       participantVisible: false,
       addParticipantVisible: false,
-      currentParticipant: realm.objects('Participant').filtered(`uuid == '${props.participant_uuid}'`)[0],
+      currentParticipant: Participant.find(props.participant_uuid),
+      participantUuid: props.participant_uuid,
     };
   }
 
   componentDidUpdate() {
     if (!this.state.participantVisible && this.props.visibleModal)
       this.setState({ participantVisible: this.props.visibleModal })
+
+    if (this.state.participantUuid != this.props.participant_uuid) {
+      this.setState({ 
+        currentParticipant: Participant.find(this.props.participant_uuid),
+        participantUuid: this.props.participant_uuid
+      });
+    }
   }
 
   _renderParticipant() {

--- a/app/components/RaisingProposed/CriteriaSelection.js
+++ b/app/components/RaisingProposed/CriteriaSelection.js
@@ -18,10 +18,14 @@ class CriteriaSelection extends Component {
       selectedIndicators: [],
       unselectedIndicators: [],
       isModalVisible: false,
+      participantUuid: props.participantUuid,
     };
   }
 
   static getDerivedStateFromProps(props, state) {
+    if (props.participantUuid != state.participantUuid)
+      return { indicators: props.indicators, selectedIndicators: props.selectedIndicators }
+
     return indicatorHelper.getIndicatorsState(props, state)
   }
 
@@ -46,7 +50,7 @@ class CriteriaSelection extends Component {
           indicators={this.state.indicators}
           selectedIndicators={this.state.selectedIndicators}
           isSearching={this.props.isSearching}
-          scorecardUuid={this.props.scorecardUUID}
+          scorecardUuid={this.props.scorecardUuid}
           selectIndicator={this.selectIndicator}
         />
       </RaisingProposedScrollView>

--- a/app/config/environment.js
+++ b/app/config/environment.js
@@ -1,5 +1,5 @@
 export const environment = {
-  domain: 'http://192.168.0.107:3000',
+  domain: 'http://192.168.0.101:3000',
   type: 'development',
   validDay: 30,
   defaultLanguage: 'km',

--- a/app/config/environment.js
+++ b/app/config/environment.js
@@ -1,5 +1,5 @@
 export const environment = {
-  domain: 'http://192.168.0.101:3000',
+  domain: 'http://192.168.0.107:3000',
   type: 'development',
   validDay: 30,
   defaultLanguage: 'km',

--- a/app/models/ProposedCriteria.js
+++ b/app/models/ProposedCriteria.js
@@ -8,6 +8,8 @@ const ProposedCriteria = (() => {
     findByParticipant,
     findByIndicator,
     findByScorecard,
+    getAllDistinctTag,
+    getAllDistinct,
     destroy,
   };
 
@@ -35,9 +37,17 @@ const ProposedCriteria = (() => {
     return realm.objects('ProposedCriteria').filtered(`scorecard_uuid = '${scorecardUuid}' AND indicatorable_id = '${indicatorableId}'`);
   }
 
-  function findByScorecard(scorecardUuid, distinctIndicator) {
-    const query = distinctIndicator ? `scorecard_uuid='${scorecardUuid}' DISTINCT(indicatorable_id)` : `scorecard_uuid='${scorecardUuid}'`;
+  function findByScorecard(scorecardUuid, distinctByIndicator) {
+    const query = distinctByIndicator ? `scorecard_uuid='${scorecardUuid}' DISTINCT(indicatorable_id)` : `scorecard_uuid='${scorecardUuid}'`;
     return realm.objects('ProposedCriteria').filtered(query);
+  }
+
+  function getAllDistinctTag(scorecardUuid) {
+    return realm.objects('ProposedCriteria').filtered(`scorecard_uuid='${scorecardUuid}' DISTINCT(tag)`);
+  }
+
+  function getAllDistinct(scorecardUuid) {
+    return realm.objects('ProposedCriteria').filtered(`scorecard_uuid='${scorecardUuid}' DISTINCT(indicatorable_id, indicatorable_type)`);
   }
 
   function destroy(proposedCriteria) {

--- a/app/models/ScorecardStep.js
+++ b/app/models/ScorecardStep.js
@@ -1,9 +1,9 @@
 import scorecardProgress from '../db/jsons/scorecardProgress';
-import proposedCriteriaService from '../services/proposedCriteriaService';
 import VotingCriteria from './VotingCriteria';
 import moment from "moment/min/moment-with-locales";
 import AsyncStorage from '@react-native-community/async-storage';
 import Participant from './Participant';
+import ProposedCriteria from './ProposedCriteria';
 
 class ScorecardStep {
   constructor() {
@@ -40,7 +40,7 @@ class ScorecardStep {
   }
 
   getProposedCriteriaSubTitle(scorecard) {
-    return proposedCriteriaService.getAllDistinct(scorecard.uuid).length;
+    return ProposedCriteria.getAllDistinct(scorecard.uuid).length;
   }
 
   getIndicatorDevelopmentSubTitle(scorecard) {

--- a/app/screens/CreateNewIndicator/CreateNewIndicator.js
+++ b/app/screens/CreateNewIndicator/CreateNewIndicator.js
@@ -26,6 +26,7 @@ import { getDeviceStyle, mobileSubTitleSize, containerPaddingTop, containerPaddi
 import customIndicatorService from '../../services/custom_indicator_service';
 
 const headerTitleSize = getDeviceStyle(18, mobileSubTitleSize());
+let _this = null;
 
 class CreateNewIndicator extends Component {
   static contextType = LocalizationContext;
@@ -45,6 +46,9 @@ class CreateNewIndicator extends Component {
       isEdit: false,
       selectedCustomIndicator: null,
     };
+    _this = this;
+
+    console.log('== participant uuid props == ', props.route.params.participant_uuid);
   }
 
   componentDidMount() {
@@ -102,7 +106,8 @@ class CreateNewIndicator extends Component {
   }
 
   save = () => {
-    const { scorecard_uuid, participant_uuid } = this.props.route.params;
+    const { scorecard_uuid } = this.props.route.params;
+    const { participant_uuid } = this.state;
     let participants = JSON.parse(JSON.stringify(Participant.findByScorecard(scorecard_uuid)));
 
     createNewIndicatorHelper.deleteUnselectedProposedIndicator(scorecard_uuid, participant_uuid, this.state.unselectedIndicators);
@@ -127,6 +132,16 @@ class CreateNewIndicator extends Component {
     );
   };
 
+  updateSelectedParticipant(participantUuid) {
+    _this.setState({
+      selectedIndicators: JSON.parse(JSON.stringify(proposedCriteriaService.getAllByParticipant(_this.props.route.params.scorecard_uuid, participantUuid))),
+      unselectedIndicators: [],
+      participant_uuid: participantUuid
+    }, () => {
+      _this._updateIndicatorList();
+    });
+  }
+
   _renderParticipant() {
     if (this.state.isSearching || this.state.isEdit)
       return;
@@ -137,6 +152,7 @@ class CreateNewIndicator extends Component {
         participantUuid={this.props.route.params.participant_uuid}
         onGetParticipant={(participant) => this.setState({participant_uuid: participant.uuid})}
         navigation={this.props.navigation}
+        updateSelectedParticipant={this.updateSelectedParticipant}
       />
     )
   }
@@ -191,8 +207,8 @@ class CreateNewIndicator extends Component {
       <CriteriaSelection
         ref={this.indicatorSelectionRef}
         selectIndicator={this.selectIndicator}
-        scorecardUUID={this.props.route.params.scorecard_uuid}
-        participantUUID={this.props.route.params.participant_uuid}
+        scorecardUuid={this.props.route.params.scorecard_uuid}
+        participantUuid={this.state.participant_uuid}
         indicators={this.state.indicators}
         selectedIndicators={this.state.selectedIndicators}
         unselectedIndicators={this.state.unselectedIndicators}


### PR DESCRIPTION
Fixing the issue when the user changes the participant in the create new indicator screen, the selected indicator doesn't store to the newly selected participant but it stores to the previously selected participant.