### PR TITLE
fix issue failed to download scorecard in production environment

### DIFF
--- a/app/services/local_file_system_service.js
+++ b/app/services/local_file_system_service.js
@@ -8,14 +8,17 @@ const downloadFileFromUrl = async (url, filename, isPdfFile, callback) => {
 
   let destinationPath = isPdfFile ? getPDFPath(filename) : getAudioPath(filename);
   let options = {
-    headers: {
-      Accept: 'application/json',
-      Authorization: `Token ${authToken}`,
-    },
     fromUrl: url,
     toFile: destinationPath,
     background,
   };
+
+  if (isPdfFile) {
+    options['headers'] = {
+      Accept: 'application/json',
+      Authorization: `Token ${authToken}`,
+    }
+  }
 
   await RNFS.downloadFile(options).promise.then(res => {
     const isSuccess = res.statusCode == 200 ? true : false;


### PR DESCRIPTION
This hotfix is to prevent the error when downloading the audio of the scorecard caused by:
- The RNFS download function has included the Authorization (token) when downloading the audio which is downloaded from S3 URL. When included the Authorization (token), it returns error status 400.

Solution:
- Remove the Authorization (token) when downloading the audio of the scorecard.
- Include the Authorization (token) when downloading the PDF of the scorecard (the URL of the scorecard, it requires authentication to access it).