### PR TITLE
Fix the error of older android version when lock the app in portrait …

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:screenOrientation="landscape"
+      android:screenOrientation="nosensor"
       android:theme="@style/AppTheme"
       android:requestLegacyExternalStorage="true">
 
@@ -31,7 +31,7 @@
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustPan"
-        android:screenOrientation="portrait">
+        android:screenOrientation="nosensor">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Fix the issue that will cause the app to crash in the android older version. This is error message is raised by Google Play showing that the app will crash when running on Android version 8.0 (SDK 26). The issue is caused by locking the app in portrait mode. To solve this error, change the android:screenOrientation="portrait" to android:screenOrientation="nosensor".

This is the link to solve this issue: https://stackoverflow.com/a/68197377/2950224
This is the list of screen orientation in Android: https://developer.android.com/guide/topics/manifest/activity-element#screen