### PR TITLE
fix the error message of java.lang.NullPointerException: Attem to inv…

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -210,8 +210,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-messaging'
 
-    implementation 'com.squareup.okhttp3:okhttp:3.12.13'
-    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.12.13'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.9'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.12.9'
     // For animated GIF support
     implementation 'com.facebook.fresco:animated-gif:2.0.0'
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
   package="org.instedd.ilabsea.community_scorecard"
   xmlns:tools="http://schemas.android.com/tools">
 
+    <queries>
+        <package android:name="org.instedd.ilabsea.community_scorecard.store" />
+        <package android:name="org.instedd.ilabsea.community_scorecard.services" />
+    </queries>
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
This pull request is fixing the message from Google Play: java.lang.NullPointerException: Attempt to invoke virtual method 'android.accounts.Account com.android.mail.providers.Account.b()' on a null object reference.

- Link to the issue message: https://play.google.com/console/u/0/developers/6365303837560226804/app/4975945976872040699/pre-launch-report/details?tab=stability&artifactId=4859625376328363391
- Issue: This issue happens on Samsung devices with the Android 10 (SDK 29) or higher. It was caused by the react-native-share library when we set the targetSdkVersion = 30, and Samsung devices can’t get an account for sharing (ex: email account).
- Solution: Adding the queries in AndroidManifest.xml as instructed in react-native-share documentation (https://react-native-share.github.io/react-native-share/docs/install/#adding-queries-for-the-android-necessary-for-sdk--30).
- Test result before and after the fixes:
[CSC mobile account issue.zip](https://github.com/ilabsea/scorecard_mobile/files/7625801/CSC.mobile.account.issue.zip)
 