### PR TITLE
include device type when the user updating the scorecard progress

### DIFF
--- a/app/services/scorecard_milestone_service.js
+++ b/app/services/scorecard_milestone_service.js
@@ -36,6 +36,7 @@ const scorecardMilestoneService = (() => {
       scorecard_progress: {
         scorecard_uuid: scorecardUuid,
         status: milestone,
+        device_type: DeviceInfo.isTablet() ? 'tablet' : 'mobile',
       }
     };
 


### PR DESCRIPTION
Include the device type (mobile or tablet) when the user updates the scorecard progress.