### PR TITLE
include device_type when submitting the scorecard and move the scorec…

### DIFF
--- a/app/helpers/proposed_indicator_helper.js
+++ b/app/helpers/proposed_indicator_helper.js
@@ -1,0 +1,40 @@
+import CustomIndicator from '../models/CustomIndicator';
+import { getAttributesByColumns } from '../helpers/scorecard_attributes_helper';
+
+const proposedIndicatorHelper = (() => {
+  return {
+    getProposedIndicatorAttributes
+  };
+
+  function getProposedIndicatorAttributes(scorecard, proposedIndicators, columns, hasTag) {
+    return proposedIndicators.map(proposedIndicator => {
+      let indicator = _getIndicatorAttrs(proposedIndicator, scorecard);
+      let attr = getAttributesByColumns(proposedIndicator, columns);
+
+      attr.indicatorable_id = indicator.id;
+      attr.indicatorable_type = indicator.type;
+
+      if (!!hasTag) {
+        attr.tag_attributes = { name: indicator.tag }
+      }
+
+      return attr;
+    })
+  }
+
+  // private methods
+  function _getIndicatorAttrs(indicator, scorecard) {
+    let indicatorable_id = indicator.indicatorable_id;
+    let indicatorable_type = 'Indicator';
+    const customIndicators = CustomIndicator.getAll(scorecard.uuid);
+
+    if (indicator.indicatorable_type != 'predefined') {
+      indicatorable_id = customIndicators.filter(x => x.uuid == indicatorable_id)[0].id_from_server;
+      indicatorable_type = 'CustomIndicator';
+    }
+
+    return { id: indicatorable_id, type: indicatorable_type };
+  }
+})();
+
+export default proposedIndicatorHelper;

--- a/app/helpers/scorecard_attributes_helper.js
+++ b/app/helpers/scorecard_attributes_helper.js
@@ -1,0 +1,5 @@
+export const getAttributesByColumns = (obj, columns) => {
+  return Object.keys(obj)
+    .filter(key => columns.indexOf(key) >= 0)
+    .reduce((obj2, key) => Object.assign(obj2, { [key]: obj[key] }), {});
+}

--- a/app/models/ProposedCriteria.js
+++ b/app/models/ProposedCriteria.js
@@ -5,6 +5,7 @@ const ProposedCriteria = (() => {
     find,
     create,
     update,
+    getAllByScorecard,
     findByParticipant,
     findByIndicator,
     findByScorecard,
@@ -29,6 +30,10 @@ const ProposedCriteria = (() => {
         realm.create('ProposedCriteria', Object.assign(params, {uuid: uuid}), 'modified');
       })
     }
+  }
+
+  function getAllByScorecard(scorecardUuid) {
+    return realm.objects('ProposedCriteria').filtered(`scorecard_uuid='${scorecardUuid}'`);
   }
 
   function findByParticipant(indicatorId, participantUuid) {

--- a/app/services/scorecardService.js
+++ b/app/services/scorecardService.js
@@ -1,5 +1,3 @@
-import Moment from 'moment';
-import realm from '../db/schema';
 import ScorecardApi from '../api/ScorecardApi';
 import CustomIndicatorApi from '../api/CustomIndicatorApi';
 import { getErrorType } from './api_service';
@@ -9,16 +7,13 @@ import scorecardMilestoneService from './scorecard_milestone_service';
 import Scorecard from '../models/Scorecard';
 import CustomIndicator from '../models/CustomIndicator';
 import Facilitator from '../models/Facilitator';
-import Participant from '../models/Participant';
 import ScorecardReference from '../models/ScorecardReference';
-import VotingCriteria from '../models/VotingCriteria';
 
-import { getSuggestedActionAttrs } from '../helpers/voting_criteria_helper';
+import { scorecardAttributes } from '../utils/scorecard_attributes_util';
 
 import BaseModelService from './baseModelService';
 import { handleApiResponse, sendRequestToApi } from './api_service';
 import { SUBMITTED } from '../constants/milestone_constant';
-import { apiDateFormat } from '../constants/date_format_constant';
 
 class ScorecardService extends BaseModelService {
 
@@ -80,7 +75,7 @@ class ScorecardService extends BaseModelService {
   // ------Step2------
   async uploadScorecard(callback, errorCallback) {
     const _this = this;
-    let attrs = this.scorecardAttr();
+    let attrs = scorecardAttributes(_this.scorecard);
 
     this.scorecardApi.put(this.scorecard_uuid, attrs)
       .then(function (response) {
@@ -110,124 +105,6 @@ class ScorecardService extends BaseModelService {
   }
 
   // Praviate methods
-  ratingsAttr() {
-    let ratings = this.getJSON('Rating');
-    let columns = ['uuid', 'scorecard_uuid', 'participant_uuid', 'score'];
-
-    return ratings.map(rating => {
-      let attr = this.getAttributes(rating, columns);
-      attr.voting_indicator_uuid = rating.voting_criteria_uuid;
-      return attr;
-    });
-  }
-
-  getIndicator(criteria) {
-    let indicatorable_id = criteria.indicatorable_id;
-    let indicatorable_type = 'Indicator';
-
-    if (criteria.indicatorable_type != 'predefined') {
-      indicatorable_id = this.customIndicators.filter(x => x.uuid == indicatorable_id)[0].id_from_server;
-      indicatorable_type = 'CustomIndicator';
-    }
-
-    return { id: indicatorable_id, type: indicatorable_type };
-  }
-
-  votingCriteriasAttr() {
-    let votingCriterias = JSON.parse(JSON.stringify(VotingCriteria.getAll(this.scorecard_uuid)));
-    let columns = ['uuid', 'scorecard_uuid', 'median', 'strength', 'weakness', 'suggested_action'];
-
-    let votingCriteriaAttr = this.getCriteriaAttr(votingCriterias, columns);
-    votingCriteriaAttr.map((votingCriteria, index) => {
-      votingCriteriaAttr[index].strength = votingCriteria.strength ? JSON.parse(votingCriteria.strength) : null;
-      votingCriteriaAttr[index].weakness = votingCriteria.weakness ? JSON.parse(votingCriteria.weakness) : null;
-      votingCriteriaAttr[index].suggested_action = votingCriteria.suggested_action ? JSON.parse(votingCriteria.suggested_action) : null;
-      votingCriteriaAttr[index].suggested_actions_attributes = getSuggestedActionAttrs(this.scorecard_uuid, votingCriteria.uuid);
-    });
-
-    return votingCriteriaAttr;
-  }
-
-  getCriteriaAttr(criterias, columns, has_tag) {
-    return criterias.map(criteria => {
-      let indicator = this.getIndicator(criteria);
-      let attr = this.getAttributes(criteria, columns);
-
-      attr.indicatorable_id = indicator.id;
-      attr.indicatorable_type = indicator.type;
-
-      if (!!has_tag) {
-        attr.tag_attributes = { name: criteria.tag }
-      }
-
-      return attr;
-    })
-  }
-
-  proposedCriteriasAttr() {
-    let proposedCriterias = this.getJSON('ProposedCriteria');
-    let columns = ['scorecard_uuid', 'participant_uuid'];
-
-    return this.getCriteriaAttr(proposedCriterias, columns, true);
-  }
-
-  scorecardAttr() {
-    let facilitators = Facilitator.getAll(this.scorecard.uuid);
-    let participants = Participant.getAll(this.scorecard.uuid);
-
-    return {
-      conducted_date: Moment(this.scorecard.conducted_date, 'DD/MM/YYYY').format(apiDateFormat),
-      number_of_caf: facilitators.length,
-      number_of_participant: participants.length,
-      number_of_female: participants.filter(p => p.gender == "female").length,
-      number_of_disability: participants.filter(p => !!p.disability).length,
-      number_of_ethnic_minority: participants.filter(p => !!p.minority).length,
-      number_of_youth: participants.filter(p => !!p.youth).length,
-      number_of_id_poor: participants.filter(p => !!p.poor).length,
-      facilitators_attributes: this.facilitatorsAttr(),
-      participants_attributes: this.participantsAttr(),
-      raised_indicators_attributes: this.proposedCriteriasAttr(),
-      voting_indicators_attributes: this.votingCriteriasAttr(),
-      ratings_attributes: this.ratingsAttr(),
-      language_conducted_code: this.scorecard.audio_language_code,
-      finished_date: this.scorecard.finished_date ? this.scorecard.finished_date : null,
-      running_date: this.scorecard.running_date ? this.scorecard.running_date : null,
-    }
-  }
-
-  participantsAttr() {
-    let participants = this.getJSON('Participant');
-    let columns = ['uuid', 'age', 'gender', 'disability', 'minority', 'youth', 'scorecard_uuid'];
-
-    return participants.map(participant => {
-      let attr = this.getAttributes(participant, columns);
-      attr.poor_card = participant.poor;
-
-      return attr;
-    });
-  }
-
-  getAttributes(obj, columns) {
-    return Object.keys(obj)
-      .filter(key => columns.indexOf(key) >= 0)
-      .reduce((obj2, key) => Object.assign(obj2, { [key]: obj[key] }), {});
-  }
-
-  facilitatorsAttr() {
-    let facilitators = Facilitator.getAll(this.scorecard_uuid);
-    let data = facilitators.map(facilitator => ({
-      caf_id: facilitator.id,
-      position: facilitator.position,
-      scorecard_uuid: facilitator.scorecard_uuid
-    }));
-
-    return data;
-  }
-
-  getJSON(realmModelName) {
-    return JSON.parse(JSON.stringify(realm.objects(realmModelName).filtered(`scorecard_uuid='${this.scorecard_uuid}'`)));
-  }
-
   customIndicatorData(indicator) {
     let attrs = {
       uuid: indicator.uuid,

--- a/app/utils/facilitator_attributes_util.js
+++ b/app/utils/facilitator_attributes_util.js
@@ -1,0 +1,20 @@
+import Facilitator from '../models/Facilitator';
+
+const facilitatorAttributesUtil = (() => {
+  return {
+    parse
+  };
+
+  function parse(scorecard) {
+    let facilitators = Facilitator.getAll(scorecard.uuid);
+    let data = facilitators.map(facilitator => ({
+      caf_id: facilitator.id,
+      position: facilitator.position,
+      scorecard_uuid: facilitator.scorecard_uuid
+    }));
+
+    return { 'facilitators_attributes': data };
+  }
+})();
+
+export default facilitatorAttributesUtil;

--- a/app/utils/participant_attributes_util.js
+++ b/app/utils/participant_attributes_util.js
@@ -1,0 +1,24 @@
+import Participant from '../models/Participant';
+import { getAttributesByColumns } from '../helpers/scorecard_attributes_helper';
+
+const participantAttributesUtil = (() => {
+  return {
+    parse
+  };
+
+  function parse(scorecard) {
+    let participants = JSON.parse(JSON.stringify(Participant.getAll(scorecard.uuid)));
+    let columns = ['uuid', 'age', 'gender', 'disability', 'minority', 'youth', 'scorecard_uuid'];
+
+    let data = participants.map(participant => {
+      let attr = getAttributesByColumns(participant, columns);
+      attr.poor_card = participant.poor;
+
+      return attr;
+    });
+
+    return { 'participants_attributes': data };
+  }
+})();
+
+export default participantAttributesUtil;

--- a/app/utils/proposed_indicator_attributes_util.js
+++ b/app/utils/proposed_indicator_attributes_util.js
@@ -1,0 +1,17 @@
+import ProposedCriteria from '../models/ProposedCriteria';
+import proposedIndicatorHelper from '../helpers/proposed_indicator_helper';
+
+const proposedIndicatorAttributesUtil = (() => {
+  return {
+    parse
+  };
+
+  function parse(scorecard) {
+    let proposedCriterias = JSON.parse(JSON.stringify(ProposedCriteria.getAllByScorecard(scorecard.uuid)));
+    let columns = ['scorecard_uuid', 'participant_uuid'];
+
+    return { 'raised_indicators_attributes': proposedIndicatorHelper.getProposedIndicatorAttributes(scorecard, proposedCriterias, columns, true) };
+  }
+})();
+
+export default proposedIndicatorAttributesUtil;

--- a/app/utils/rating_attributes_util.js
+++ b/app/utils/rating_attributes_util.js
@@ -1,0 +1,23 @@
+import Rating from '../models/Rating';
+import { getAttributesByColumns } from '../helpers/scorecard_attributes_helper';
+
+const ratingAttributesHelper = (() => {
+  return {
+    parse
+  };
+
+  function parse(scorecard) {
+    let ratings = JSON.parse(JSON.stringify(Rating.getAll(scorecard.uuid)));
+    let columns = ['uuid', 'scorecard_uuid', 'participant_uuid', 'score'];
+
+    let data = ratings.map(rating => {
+      let attr = getAttributesByColumns(rating, columns);
+      attr.voting_indicator_uuid = rating.voting_criteria_uuid;
+      return attr;
+    });
+
+    return { 'ratings_attributes': data };
+  }
+})();
+
+export default ratingAttributesHelper;

--- a/app/utils/scorecard_attributes_util.js
+++ b/app/utils/scorecard_attributes_util.js
@@ -1,0 +1,128 @@
+import Moment from 'moment';
+import DeviceInfo from 'react-native-device-info'
+import realm from '../db/schema';
+import Facilitator from '../models/Facilitator';
+import Participant from '../models/Participant';
+import VotingCriteria from '../models/VotingCriteria';
+import { getSuggestedActionAttrs } from '../helpers/voting_criteria_helper';
+import { apiDateFormat } from '../constants/date_format_constant';
+
+export const scorecardAttributes = (scorecard) => {
+  let facilitators = Facilitator.getAll(scorecard.uuid);
+  let participants = Participant.getAll(scorecard.uuid);
+
+  return {
+    conducted_date: Moment(scorecard.conducted_date, 'DD/MM/YYYY').format(apiDateFormat),
+    number_of_caf: facilitators.length,
+    number_of_participant: participants.length,
+    number_of_female: participants.filter(p => p.gender == "female").length,
+    number_of_disability: participants.filter(p => !!p.disability).length,
+    number_of_ethnic_minority: participants.filter(p => !!p.minority).length,
+    number_of_youth: participants.filter(p => !!p.youth).length,
+    number_of_id_poor: participants.filter(p => !!p.poor).length,
+    facilitators_attributes: _facilitatorsAttrs(scorecard),
+    participants_attributes: _participantsAttrs(scorecard),
+    raised_indicators_attributes: _proposedCriteriasAttrs(scorecard),
+    voting_indicators_attributes: _votingCriteriasAttrs(scorecard),
+    ratings_attributes: _ratingsAttrs(scorecard),
+    language_conducted_code: scorecard.audio_language_code,
+    finished_date: scorecard.finished_date ? scorecard.finished_date : null,
+    running_date: scorecard.running_date ? scorecard.running_date : null,
+    device_type: DeviceInfo.isTablet() ? 'tablet' : 'mobile'
+  }
+}
+
+// Private methods
+const _facilitatorsAttrs = (scorecard) => {
+  let facilitators = Facilitator.getAll(scorecard.uuid);
+  let data = facilitators.map(facilitator => ({
+    caf_id: facilitator.id,
+    position: facilitator.position,
+    scorecard_uuid: facilitator.scorecard_uuid
+  }));
+
+  return data;
+}
+
+const _participantsAttrs = (scorecard) => {
+  let participants = _getJSON('Participant', scorecard);
+  let columns = ['uuid', 'age', 'gender', 'disability', 'minority', 'youth', 'scorecard_uuid'];
+
+  return participants.map(participant => {
+    let attr = _getAttributes(participant, columns);
+    attr.poor_card = participant.poor;
+
+    return attr;
+  });
+}
+
+const _proposedCriteriasAttrs = (scorecard) => {
+  let proposedCriterias = _getJSON('ProposedCriteria', scorecard);
+  let columns = ['scorecard_uuid', 'participant_uuid'];
+
+  return _getCriteriaAttrs(proposedCriterias, columns, true);
+}
+
+const _votingCriteriasAttrs = (scorecard) => {
+  let votingCriterias = JSON.parse(JSON.stringify(VotingCriteria.getAll(scorecard.uuid)));
+  let columns = ['uuid', 'scorecard_uuid', 'median', 'strength', 'weakness', 'suggested_action'];
+
+  let votingCriteriaAttr = _getCriteriaAttrs(votingCriterias, columns);
+  votingCriteriaAttr.map((votingCriteria, index) => {
+    votingCriteriaAttr[index].strength = votingCriteria.strength ? JSON.parse(votingCriteria.strength) : null;
+    votingCriteriaAttr[index].weakness = votingCriteria.weakness ? JSON.parse(votingCriteria.weakness) : null;
+    votingCriteriaAttr[index].suggested_action = votingCriteria.suggested_action ? JSON.parse(votingCriteria.suggested_action) : null;
+    votingCriteriaAttr[index].suggested_actions_attributes = getSuggestedActionAttrs(scorecard.uuid, votingCriteria.uuid);
+  });
+
+  return votingCriteriaAttr;
+}
+
+const _ratingsAttrs = (scorecard) => {
+  let ratings = _getJSON('Rating', scorecard);
+  let columns = ['uuid', 'scorecard_uuid', 'participant_uuid', 'score'];
+
+  return ratings.map(rating => {
+    let attr = _getAttributes(rating, columns);
+    attr.voting_indicator_uuid = rating.voting_criteria_uuid;
+    return attr;
+  });
+}
+
+const _getAttributes = (obj, columns) => {
+  return Object.keys(obj)
+    .filter(key => columns.indexOf(key) >= 0)
+    .reduce((obj2, key) => Object.assign(obj2, { [key]: obj[key] }), {});
+}
+
+const _getCriteriaAttrs = (criterias, columns, has_tag) => {
+  return criterias.map(criteria => {
+    let indicator = _getIndicator(criteria);
+    let attr = _getAttributes(criteria, columns);
+
+    attr.indicatorable_id = indicator.id;
+    attr.indicatorable_type = indicator.type;
+
+    if (!!has_tag) {
+      attr.tag_attributes = { name: criteria.tag }
+    }
+
+    return attr;
+  })
+}
+
+const _getIndicator = (criteria) => {
+  let indicatorable_id = criteria.indicatorable_id;
+  let indicatorable_type = 'Indicator';
+
+  if (criteria.indicatorable_type != 'predefined') {
+    indicatorable_id = this.customIndicators.filter(x => x.uuid == indicatorable_id)[0].id_from_server;
+    indicatorable_type = 'CustomIndicator';
+  }
+
+  return { id: indicatorable_id, type: indicatorable_type };
+}
+
+const _getJSON = (realmModelName, scorecard) => {
+  return JSON.parse(JSON.stringify(realm.objects(realmModelName).filtered(`scorecard_uuid='${scorecard.uuid}'`)));
+}

--- a/app/utils/scorecard_attributes_util.js
+++ b/app/utils/scorecard_attributes_util.js
@@ -1,17 +1,15 @@
 import Moment from 'moment';
 import DeviceInfo from 'react-native-device-info'
-import realm from '../db/schema';
 import Facilitator from '../models/Facilitator';
 import Participant from '../models/Participant';
-import VotingCriteria from '../models/VotingCriteria';
-import { getSuggestedActionAttrs } from '../helpers/voting_criteria_helper';
 import { apiDateFormat } from '../constants/date_format_constant';
+import { getNestedAttributes } from './scorecard_nested_attributes_util';
 
 export const scorecardAttributes = (scorecard) => {
   let facilitators = Facilitator.getAll(scorecard.uuid);
   let participants = Participant.getAll(scorecard.uuid);
 
-  return {
+  let scorecardAttributes = {
     conducted_date: Moment(scorecard.conducted_date, 'DD/MM/YYYY').format(apiDateFormat),
     number_of_caf: facilitators.length,
     number_of_participant: participants.length,
@@ -20,109 +18,13 @@ export const scorecardAttributes = (scorecard) => {
     number_of_ethnic_minority: participants.filter(p => !!p.minority).length,
     number_of_youth: participants.filter(p => !!p.youth).length,
     number_of_id_poor: participants.filter(p => !!p.poor).length,
-    facilitators_attributes: _facilitatorsAttrs(scorecard),
-    participants_attributes: _participantsAttrs(scorecard),
-    raised_indicators_attributes: _proposedCriteriasAttrs(scorecard),
-    voting_indicators_attributes: _votingCriteriasAttrs(scorecard),
-    ratings_attributes: _ratingsAttrs(scorecard),
     language_conducted_code: scorecard.audio_language_code,
     finished_date: scorecard.finished_date ? scorecard.finished_date : null,
     running_date: scorecard.running_date ? scorecard.running_date : null,
-    device_type: DeviceInfo.isTablet() ? 'tablet' : 'mobile'
-  }
-}
+    device_type: DeviceInfo.isTablet() ? 'tablet' : 'mobile',
+  };
 
-// Private methods
-const _facilitatorsAttrs = (scorecard) => {
-  let facilitators = Facilitator.getAll(scorecard.uuid);
-  let data = facilitators.map(facilitator => ({
-    caf_id: facilitator.id,
-    position: facilitator.position,
-    scorecard_uuid: facilitator.scorecard_uuid
-  }));
+  scorecardAttributes = {...scorecardAttributes, ...getNestedAttributes(scorecard)};
 
-  return data;
-}
-
-const _participantsAttrs = (scorecard) => {
-  let participants = _getJSON('Participant', scorecard);
-  let columns = ['uuid', 'age', 'gender', 'disability', 'minority', 'youth', 'scorecard_uuid'];
-
-  return participants.map(participant => {
-    let attr = _getAttributes(participant, columns);
-    attr.poor_card = participant.poor;
-
-    return attr;
-  });
-}
-
-const _proposedCriteriasAttrs = (scorecard) => {
-  let proposedCriterias = _getJSON('ProposedCriteria', scorecard);
-  let columns = ['scorecard_uuid', 'participant_uuid'];
-
-  return _getCriteriaAttrs(proposedCriterias, columns, true);
-}
-
-const _votingCriteriasAttrs = (scorecard) => {
-  let votingCriterias = JSON.parse(JSON.stringify(VotingCriteria.getAll(scorecard.uuid)));
-  let columns = ['uuid', 'scorecard_uuid', 'median', 'strength', 'weakness', 'suggested_action'];
-
-  let votingCriteriaAttr = _getCriteriaAttrs(votingCriterias, columns);
-  votingCriteriaAttr.map((votingCriteria, index) => {
-    votingCriteriaAttr[index].strength = votingCriteria.strength ? JSON.parse(votingCriteria.strength) : null;
-    votingCriteriaAttr[index].weakness = votingCriteria.weakness ? JSON.parse(votingCriteria.weakness) : null;
-    votingCriteriaAttr[index].suggested_action = votingCriteria.suggested_action ? JSON.parse(votingCriteria.suggested_action) : null;
-    votingCriteriaAttr[index].suggested_actions_attributes = getSuggestedActionAttrs(scorecard.uuid, votingCriteria.uuid);
-  });
-
-  return votingCriteriaAttr;
-}
-
-const _ratingsAttrs = (scorecard) => {
-  let ratings = _getJSON('Rating', scorecard);
-  let columns = ['uuid', 'scorecard_uuid', 'participant_uuid', 'score'];
-
-  return ratings.map(rating => {
-    let attr = _getAttributes(rating, columns);
-    attr.voting_indicator_uuid = rating.voting_criteria_uuid;
-    return attr;
-  });
-}
-
-const _getAttributes = (obj, columns) => {
-  return Object.keys(obj)
-    .filter(key => columns.indexOf(key) >= 0)
-    .reduce((obj2, key) => Object.assign(obj2, { [key]: obj[key] }), {});
-}
-
-const _getCriteriaAttrs = (criterias, columns, has_tag) => {
-  return criterias.map(criteria => {
-    let indicator = _getIndicator(criteria);
-    let attr = _getAttributes(criteria, columns);
-
-    attr.indicatorable_id = indicator.id;
-    attr.indicatorable_type = indicator.type;
-
-    if (!!has_tag) {
-      attr.tag_attributes = { name: criteria.tag }
-    }
-
-    return attr;
-  })
-}
-
-const _getIndicator = (criteria) => {
-  let indicatorable_id = criteria.indicatorable_id;
-  let indicatorable_type = 'Indicator';
-
-  if (criteria.indicatorable_type != 'predefined') {
-    indicatorable_id = this.customIndicators.filter(x => x.uuid == indicatorable_id)[0].id_from_server;
-    indicatorable_type = 'CustomIndicator';
-  }
-
-  return { id: indicatorable_id, type: indicatorable_type };
-}
-
-const _getJSON = (realmModelName, scorecard) => {
-  return JSON.parse(JSON.stringify(realm.objects(realmModelName).filtered(`scorecard_uuid='${scorecard.uuid}'`)));
+  return scorecardAttributes;
 }

--- a/app/utils/scorecard_nested_attributes_util.js
+++ b/app/utils/scorecard_nested_attributes_util.js
@@ -1,0 +1,23 @@
+import facilitatorAttributesUtil from './facilitator_attributes_util';
+import participantAttributesUtil from './participant_attributes_util';
+import proposedIndicatorAttributesUtil from './proposed_indicator_attributes_util';
+import votingAttributesUtil from './voting_attributes_util';
+import ratingAttributesUtil from './rating_attributes_util';
+
+export const getNestedAttributes = (scorecard) => {
+  const nestedScorecardAttributes = [
+    facilitatorAttributesUtil,
+    participantAttributesUtil,
+    proposedIndicatorAttributesUtil,
+    votingAttributesUtil,
+    ratingAttributesUtil
+  ];
+
+  let nestedAttributes = {};
+
+  nestedScorecardAttributes.map(scorecardAttribute => {
+    nestedAttributes = {...nestedAttributes, ...scorecardAttribute.parse(scorecard)}
+  });
+
+  return nestedAttributes;
+}

--- a/app/utils/voting_attributes_util.js
+++ b/app/utils/voting_attributes_util.js
@@ -1,0 +1,26 @@
+import VotingCriteria from '../models/VotingCriteria';
+import { getSuggestedActionAttrs } from '../helpers/voting_criteria_helper';
+import proposedIndicatorHelper from '../helpers/proposed_indicator_helper';
+
+const votingAttributesHelper = (() => {
+  return {
+    parse
+  }
+
+  function parse(scorecard) {
+    let votingCriterias = JSON.parse(JSON.stringify(VotingCriteria.getAll(scorecard.uuid)));
+    let columns = ['uuid', 'scorecard_uuid', 'median', 'strength', 'weakness', 'suggested_action'];
+    let votingCriteriaAttr = proposedIndicatorHelper.getProposedIndicatorAttributes(scorecard, votingCriterias, columns);
+
+    votingCriteriaAttr.map((votingCriteria, index) => {
+      votingCriteriaAttr[index].strength = votingCriteria.strength ? JSON.parse(votingCriteria.strength) : null;
+      votingCriteriaAttr[index].weakness = votingCriteria.weakness ? JSON.parse(votingCriteria.weakness) : null;
+      votingCriteriaAttr[index].suggested_action = votingCriteria.suggested_action ? JSON.parse(votingCriteria.suggested_action) : null;
+      votingCriteriaAttr[index].suggested_actions_attributes = getSuggestedActionAttrs(scorecard.uuid, votingCriteria.uuid);
+    });
+
+    return { 'voting_indicators_attributes': votingCriteriaAttr };
+  }
+})();
+
+export default votingAttributesHelper;


### PR DESCRIPTION
In this pull request, we include the device_type when the user submits the scorecard. From the mobile side, we pass the device_type as 'tablet' or 'mobile', and at the server-side, it will handle to store the data as 0 or 1.