### PR TITLE
Improve accessibility UI on filter scorecard screen

### DIFF
--- a/app/components/CreateNewIndicator/SearchableHeader.js
+++ b/app/components/CreateNewIndicator/SearchableHeader.js
@@ -5,7 +5,8 @@ import { HeaderBackButton } from '@react-navigation/stack';
 import CreateNewIndicatorTitle from './CreateNewIndicatorTitle';
 import CreateNewIndicatorSearchInput from './CreateNewIndicatorSearchInput';
 import IndicatorService from '../../services/indicator_service';
-import { getDeviceStyle, navigationBackButtonFlex } from '../../utils/responsive_util';
+import { getDeviceStyle } from '../../utils/responsive_util';
+import { pressableItemSize } from '../../constants/components_size_constant';
 
 class SearchableHeader extends Component {
   constructor(props) {
@@ -63,8 +64,8 @@ class SearchableHeader extends Component {
   render() {
     return (
       <Header searchBar>
-        <Left style={{flex: navigationBackButtonFlex, marginLeft: getDeviceStyle(-10, 0), justifyContent: 'center'}}>
-          <HeaderBackButton tintColor={"#fff"} onPress={() => this._onPress()} style={{ marginLeft: getDeviceStyle(11, 0) }} />
+        <Left style={{flex: 0.22, marginLeft: getDeviceStyle(-10, 0), justifyContent: 'center'}}>
+          <HeaderBackButton tintColor={"#fff"} onPress={() => this._onPress()} style={{ marginLeft: getDeviceStyle(11, 0), width: pressableItemSize, height: pressableItemSize }} />
         </Left>
         { !this.props.isSearching ? this._renderTitle() : this._renderSearchBox() }
       </Header>

--- a/app/components/FilterScorecard/FilterOption.js
+++ b/app/components/FilterScorecard/FilterOption.js
@@ -28,7 +28,7 @@ class FilterOption extends Component {
       return (
         <View key={uuidv4()}>
           <TouchableOpacity onPress={() => this.props.onSelectItem(option.value)}
-            style={{flexDirection: 'row', paddingRight: 25, paddingLeft: 30, paddingVertical: 10, alignItems: 'center'}}
+            style={{flexDirection: 'row', paddingRight: 25, paddingLeft: 30, paddingVertical: 10, alignItems: 'center', height: 50}}
           >
             <Text style={{flex: 1, fontSize: getDeviceStyle(16, wp(mdLabelSize))}}>{ translations[option.label] }</Text>
 
@@ -43,7 +43,9 @@ class FilterOption extends Component {
   render() {
     return (
       <View style={[this.props.containerStyle, { backgroundColor: Color.whiteColor }]}>
-        <Text style={{paddingHorizontal: 16, paddingVertical: 10, fontSize: getDeviceStyle(16, wp(mdLabelSize)), fontFamily: FontFamily.title, backgroundColor: Color.whiteColor}}>
+        <Text style={{paddingHorizontal: 16, paddingVertical: 10, fontSize: getDeviceStyle(16, wp(mdLabelSize)),
+          fontFamily: FontFamily.title, backgroundColor: Color.whiteColor, height: 49}}
+        >
           { this.props.title }
         </Text>
         { this.renderOptionList() }

--- a/app/components/FilterScorecard/FilterScorecardHeader.js
+++ b/app/components/FilterScorecard/FilterScorecardHeader.js
@@ -5,6 +5,7 @@ import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import { LocalizationContext } from '../Translations';
 import NavigationHeader from '../NavigationHeader';
 import { getDeviceStyle, mobileHeadingTitleSize, isShortWidthScreen } from '../../utils/responsive_util';
+import { pressableItemSize } from '../../constants/components_size_constant';
 
 class FilterScorecardHeader extends Component {
   static contextType = LocalizationContext;
@@ -15,7 +16,7 @@ class FilterScorecardHeader extends Component {
 
   renderRightButton() {
     return (
-      <Button transparent onPress={() => this.props.resetFilter()} style={{padding: 0}}>
+      <Button transparent onPress={() => this.props.resetFilter()} style={{padding: 0, height: pressableItemSize}}>
         <Title style={{fontSize: getDeviceStyle(19, mobileHeadingTitleSize())}}>{ this.context.translations.reset }</Title>
       </Button>
     )

--- a/app/components/FilterScorecard/LocationSearchBox.js
+++ b/app/components/FilterScorecard/LocationSearchBox.js
@@ -15,11 +15,12 @@ class LocationSearchBox extends Component {
 
   render() {
     const { translations } = this.context;
+    const placeholderColor = '#676767';
 
     return (
       <View style={styles.container}>
         <Item rounded style={[styles.inputContainer, this.props.searchedLocation ? { marginRight: 15 } : {}]}>
-          <Icon name="search" style={{fontSize: 22, paddingLeft: 10, paddingRight: 0, marginTop: 0, color: Color.grayColor}} />
+          <Icon name="search" style={{fontSize: 22, paddingLeft: 10, paddingRight: 0, marginTop: 0, color: placeholderColor}} />
           <Input
             placeholder={ translations.searchLocation }
             value={this.props.searchedLocation}
@@ -28,6 +29,7 @@ class LocationSearchBox extends Component {
             onChangeText={(text) => this.props.onChangeText(text)}
             onFocus={() => this.props.updateFocusStatus(true)}
             onBlur={() => this.props.updateFocusStatus(false)}
+            placeholderTextColor={placeholderColor}
           />
         </Item>
 
@@ -44,7 +46,7 @@ class LocationSearchBox extends Component {
 const styles = StyleSheet.create({
   inputContainer: {
     borderRadius: 10,
-    borderColor: Color.grayColor,
+    borderColor: '#bababa',
     flex: 1,
     backgroundColor: Color.paleGrayColor
   },

--- a/app/components/NavigationHeader.js
+++ b/app/components/NavigationHeader.js
@@ -6,13 +6,14 @@ import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import NavigationHeaderBody from './NavigationHeaderBody'
 import Color from '../themes/color';
 import { getDeviceStyle, navigationBackButtonFlex } from '../utils/responsive_util';
+import { pressableItemSize } from '../constants/components_size_constant';
 
 class NavigationHeader extends Component {
   render() {
     return (
       <Header style={{alignItems: 'center'}}>
         <Left style={{ flex: navigationBackButtonFlex }}>
-          <HeaderBackButton tintColor={Color.whiteColor} onPress={() => this.props.onBackPress()} style={{ marginLeft: 0 }} />
+          <HeaderBackButton tintColor={Color.whiteColor} onPress={() => this.props.onBackPress()} style={{ marginLeft: 0, width: pressableItemSize, height: pressableItemSize }} />
         </Left>
 
         <NavigationHeaderBody title={this.props.title} />

--- a/app/constants/components_size_constant.js
+++ b/app/constants/components_size_constant.js
@@ -1,0 +1,1 @@
+export const pressableItemSize = 48;

--- a/app/screens/FilterScorecard/FilterScorecard.js
+++ b/app/screens/FilterScorecard/FilterScorecard.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, Text, ScrollView } from 'react-native';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import AsyncStorage from '@react-native-community/async-storage';
 
@@ -121,7 +121,7 @@ class FilterScorecard extends Component {
         <ScrollView contentContainerStyle={{flexGrow: 1, paddingBottom: this.state.isSearchBoxFocused ? 300 : 20 }} stickyHeaderIndices={[2]}>
           { this.renderScorecardStatusAndTypeOptions() }
 
-          <Text style={{paddingHorizontal: 16, paddingVertical: 10, fontSize: getDeviceStyle(16, wp(mdLabelSize)), marginTop: 20, fontFamily: FontFamily.title, backgroundColor: Color.whiteColor}}>
+          <Text style={{paddingHorizontal: 16, paddingVertical: 10, fontSize: getDeviceStyle(16, wp(mdLabelSize)), marginTop: 20, fontFamily: FontFamily.title, backgroundColor: Color.whiteColor, height: 49}}>
             { translations.scorecardLocation }
           </Text>
 
@@ -134,5 +134,12 @@ class FilterScorecard extends Component {
     )
   }
 }
+
+const styles = StyleSheet.create({
+  sectionHeader: {
+    paddingHorizontal: 16, paddingVertical: 10, fontSize: getDeviceStyle(16, wp(mdLabelSize)),
+    marginTop: 20, fontFamily: FontFamily.title, backgroundColor: Color.whiteColor, height: 48
+  }
+});
 
 export default FilterScorecard;

--- a/app/screens/FilterScorecard/FilterScorecard.js
+++ b/app/screens/FilterScorecard/FilterScorecard.js
@@ -135,11 +135,4 @@ class FilterScorecard extends Component {
   }
 }
 
-const styles = StyleSheet.create({
-  sectionHeader: {
-    paddingHorizontal: 16, paddingVertical: 10, fontSize: getDeviceStyle(16, wp(mdLabelSize)),
-    marginTop: 20, fontFamily: FontFamily.title, backgroundColor: Color.whiteColor, height: 48
-  }
-});
-
 export default FilterScorecard;

--- a/app/styles/tablet/CreateNewIndicatorTitleComponentStyle.js
+++ b/app/styles/tablet/CreateNewIndicatorTitleComponentStyle.js
@@ -6,7 +6,7 @@ import { FontFamily } from '../../assets/stylesheets/theme/font';
 const CreateNewIndicatorTitleStyles = StyleSheet.create({
   body: {
     flex: 2,
-    paddingLeft: wp('1.4%'),
+    marginLeft: 18
   },
   titleLabel: {
     fontSize: 19,

--- a/app/utils/responsive_util.js
+++ b/app/utils/responsive_util.js
@@ -62,7 +62,7 @@ const containerPadding = getDeviceStyle(20, 15);
 
 const navigationTitlePaddingLeft = getDeviceStyle(0, isShortWidthScreen() ? wp('4%') : wp('1%'));
 
-const navigationBackButtonFlex = 0.22;
+const navigationBackButtonFlex = 0.26;
 
 export {
   getDeviceStyle,


### PR DESCRIPTION
This pull request is for improving the accessibility UI of the filter scorecard screen by:
- Update the width and height of the header button to 48dp
- Update the height of the filter list item to 50dp
- Make the color of the search icon in the search box more contrast with the input background-color
- Make the border color of the search box less contrast with the input background-color
[filter scorecard screen.zip](https://github.com/ilabsea/scorecard_mobile/files/7674724/filter.scorecard.screen.zip)

