### PR TITLE
Improve accessibility UI of new scorecard screen

### DIFF
--- a/app/components/CloseButton.js
+++ b/app/components/CloseButton.js
@@ -2,15 +2,17 @@ import React from 'react';
 import { Button } from 'react-native-paper';
 import Color from '../themes/color';
 import { normalLabelSize } from '../utils/responsive_util';
+import { pressableItemSize } from '../utils/component_util';
+import { modalButtonPaddingVertical } from '../constants/component_style_constant';
 
 const CloseButton = (props) => {
   return (
     <Button
       {...props}
       mode="outlined"
-      style={{ borderWidth: 2, borderColor: Color.primaryButtonColor, height: 51 }}
+      style={{ borderWidth: 2, borderColor: Color.primaryButtonColor, height: pressableItemSize(modalButtonPaddingVertical) }}
       labelStyle={{fontSize: normalLabelSize}}
-      contentStyle={{height: 51, marginTop: -2}}
+      contentStyle={{height: pressableItemSize(modalButtonPaddingVertical), marginTop: -2}}
     >
       {props.label}
     </Button>

--- a/app/components/CloseButton.js
+++ b/app/components/CloseButton.js
@@ -8,8 +8,9 @@ const CloseButton = (props) => {
     <Button
       {...props}
       mode="outlined"
-      style={{ borderWidth: 2, borderColor: Color.primaryButtonColor }}
+      style={{ borderWidth: 2, borderColor: Color.primaryButtonColor, height: 51 }}
       labelStyle={{fontSize: normalLabelSize}}
+      contentStyle={{height: 51, marginTop: -2}}
     >
       {props.label}
     </Button>

--- a/app/components/CreateNewIndicator/SearchableHeader.js
+++ b/app/components/CreateNewIndicator/SearchableHeader.js
@@ -6,7 +6,7 @@ import CreateNewIndicatorTitle from './CreateNewIndicatorTitle';
 import CreateNewIndicatorSearchInput from './CreateNewIndicatorSearchInput';
 import IndicatorService from '../../services/indicator_service';
 import { getDeviceStyle } from '../../utils/responsive_util';
-import { pressableItemSize } from '../../constants/components_size_constant';
+import { pressableItemSize } from '../../utils/component_util';
 
 class SearchableHeader extends Component {
   constructor(props) {
@@ -65,7 +65,7 @@ class SearchableHeader extends Component {
     return (
       <Header searchBar>
         <Left style={{flex: 0.22, marginLeft: getDeviceStyle(-10, 0), justifyContent: 'center'}}>
-          <HeaderBackButton tintColor={"#fff"} onPress={() => this._onPress()} style={{ marginLeft: getDeviceStyle(11, 0), width: pressableItemSize, height: pressableItemSize }} />
+          <HeaderBackButton tintColor={"#fff"} onPress={() => this._onPress()} style={{ marginLeft: getDeviceStyle(11, 0), width: pressableItemSize(), height: pressableItemSize() }} />
         </Left>
         { !this.props.isSearching ? this._renderTitle() : this._renderSearchBox() }
       </Header>

--- a/app/components/ErrorMessageModal/ErrorAuthenticationContent.js
+++ b/app/components/ErrorMessageModal/ErrorAuthenticationContent.js
@@ -91,6 +91,8 @@ class ErrorAuthenticationContent extends Component {
         name={this.state.showPasswordIcon}
         color="#959595"
         onPress={() => this.setState({ showPasswordIcon: this.state.showPasswordIcon == 'eye' ? 'eye-off' : 'eye' })}
+        accessibilityLabel='Toggle password visibility'
+        style={{height: 50, width: 50}}
       />
     )
   }

--- a/app/components/ErrorMessageModal/ErrorAuthenticationContent.js
+++ b/app/components/ErrorMessageModal/ErrorAuthenticationContent.js
@@ -13,6 +13,7 @@ import authenticationFormService from '../../services/authentication_form_servic
 
 import ModalConfirmationButtons from '../ModalConfirmationButtons';
 
+import { pressableItemSize } from '../../utils/component_util';
 import { getDeviceStyle } from '../../utils/responsive_util';
 import PopupModalTabletStyles from '../../styles/tablet/PopupModalComponentStyle';
 import PopupModalMobileStyles from '../../styles/mobile/PopupModalComponentStyle';
@@ -86,13 +87,15 @@ class ErrorAuthenticationContent extends Component {
   }
 
   _renderShowPasswordIcon = () => {
+    const buttonPadding = 2;
+
     return (
       <TextInput.Icon
         name={this.state.showPasswordIcon}
         color="#959595"
         onPress={() => this.setState({ showPasswordIcon: this.state.showPasswordIcon == 'eye' ? 'eye-off' : 'eye' })}
         accessibilityLabel='Toggle password visibility'
-        style={{height: 50, width: 50}}
+        style={{height: pressableItemSize(buttonPadding), width: pressableItemSize(buttonPadding)}}
       />
     )
   }

--- a/app/components/FilterScorecard/FilterOption.js
+++ b/app/components/FilterScorecard/FilterOption.js
@@ -9,6 +9,7 @@ import Color from '../../themes/color';
 import { FontFamily } from '../../assets/stylesheets/theme/font';
 import { getDeviceStyle } from '../../utils/responsive_util';
 import uuidv4 from '../../utils/uuidv4';
+import { pressableItemSize } from '../../utils/component_util';
 import { mdLabelSize } from '../../constants/mobile_font_size_constant';
 
 class FilterOption extends Component {
@@ -23,12 +24,13 @@ class FilterOption extends Component {
 
   renderOptionList() {
     const { translations } = this.context;
+    const itemPaddingVertical = 12;
 
     return this.props.options.map((option, index) => {
       return (
         <View key={uuidv4()}>
           <TouchableOpacity onPress={() => this.props.onSelectItem(option.value)}
-            style={{flexDirection: 'row', paddingRight: 25, paddingLeft: 30, paddingVertical: 10, alignItems: 'center', height: 50}}
+            style={{flexDirection: 'row', paddingRight: 25, paddingLeft: 30, alignItems: 'center', height: pressableItemSize(itemPaddingVertical)}}
           >
             <Text style={{flex: 1, fontSize: getDeviceStyle(16, wp(mdLabelSize))}}>{ translations[option.label] }</Text>
 
@@ -43,11 +45,12 @@ class FilterOption extends Component {
   render() {
     return (
       <View style={[this.props.containerStyle, { backgroundColor: Color.whiteColor }]}>
-        <Text style={{paddingHorizontal: 16, paddingVertical: 10, fontSize: getDeviceStyle(16, wp(mdLabelSize)),
-          fontFamily: FontFamily.title, backgroundColor: Color.whiteColor, height: 49}}
-        >
-          { this.props.title }
-        </Text>
+        <View style={{paddingHorizontal: 16, paddingVertical: 10, backgroundColor: Color.whiteColor, justifyContent: 'center'}}>
+          <Text style={{fontSize: getDeviceStyle(16, wp(mdLabelSize)), fontFamily: FontFamily.title}}>
+            { this.props.title }
+          </Text>
+        </View>
+
         { this.renderOptionList() }
       </View>
     )

--- a/app/components/FilterScorecard/FilterScorecardHeader.js
+++ b/app/components/FilterScorecard/FilterScorecardHeader.js
@@ -5,7 +5,7 @@ import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import { LocalizationContext } from '../Translations';
 import NavigationHeader from '../NavigationHeader';
 import { getDeviceStyle, mobileHeadingTitleSize, isShortWidthScreen } from '../../utils/responsive_util';
-import { pressableItemSize } from '../../constants/components_size_constant';
+import { pressableItemSize } from '../../utils/component_util';
 
 class FilterScorecardHeader extends Component {
   static contextType = LocalizationContext;
@@ -16,7 +16,7 @@ class FilterScorecardHeader extends Component {
 
   renderRightButton() {
     return (
-      <Button transparent onPress={() => this.props.resetFilter()} style={{padding: 0, height: pressableItemSize}}>
+      <Button transparent onPress={() => this.props.resetFilter()} style={{padding: 0, height: pressableItemSize()}}>
         <Title style={{fontSize: getDeviceStyle(19, mobileHeadingTitleSize())}}>{ this.context.translations.reset }</Title>
       </Button>
     )

--- a/app/components/NavigationHeader.js
+++ b/app/components/NavigationHeader.js
@@ -6,14 +6,14 @@ import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import NavigationHeaderBody from './NavigationHeaderBody'
 import Color from '../themes/color';
 import { getDeviceStyle, navigationBackButtonFlex } from '../utils/responsive_util';
-import { pressableItemSize } from '../constants/components_size_constant';
+import { pressableItemSize } from '../utils/component_util';
 
 class NavigationHeader extends Component {
   render() {
     return (
       <Header style={{alignItems: 'center'}}>
         <Left style={{ flex: navigationBackButtonFlex }}>
-          <HeaderBackButton tintColor={Color.whiteColor} onPress={() => this.props.onBackPress()} style={{ marginLeft: 0, width: pressableItemSize, height: pressableItemSize }} />
+          <HeaderBackButton tintColor={Color.whiteColor} onPress={() => this.props.onBackPress()} style={{ marginLeft: 0, width: pressableItemSize(), height: pressableItemSize() }} />
         </Left>
 
         <NavigationHeaderBody title={this.props.title} />

--- a/app/components/NewScorecard/ButtonForgetCode.js
+++ b/app/components/NewScorecard/ButtonForgetCode.js
@@ -18,7 +18,7 @@ class ButtonForgetCode extends Component {
     const { translations } = this.context;
 
     return (
-      <View style={responsiveStyles.container}>
+      <View style={[responsiveStyles.container, this.props.hasErrorMsg ? responsiveStyles.containerMarginBottom : {}]}>
         <TouchableOpacity
           onPress={() => this.props.navigation.navigate('Contact')}
           style={responsiveStyles.button}>

--- a/app/components/NewScorecard/NewScorecardForm.js
+++ b/app/components/NewScorecard/NewScorecardForm.js
@@ -68,7 +68,7 @@ class NewScorecardForm extends Component {
 
         {this.renderErrorMsg()}
 
-        <ButtonForgetCode navigation={this.props.navigation} />
+        <ButtonForgetCode navigation={this.props.navigation} hasErrorMsg={this.props.errorMsg != '' ? true : false} />
       </View>
     )
   }

--- a/app/components/OutlinedButton.js
+++ b/app/components/OutlinedButton.js
@@ -4,6 +4,7 @@ import { Button, Icon, Text } from 'native-base';
 import Color from '../themes/color';
 
 import { getDeviceStyle } from '../utils/responsive_util';
+import { pressableItemSize } from '../constants/components_size_constant';
 import OutlinedButtonTabletStyles from '../styles/tablet/OutlinedButtonComponentStyle';
 import OutlinedButtonMobileStyles from '../styles/mobile/OutlinedButtonComponentStyle';
 
@@ -16,7 +17,7 @@ class OutlinedButton extends Component {
         {...this.props}
         bordered
         iconLeft
-        style={{padding: 0, height: 48}}
+        style={{padding: 0, height: pressableItemSize}}
       >
         <Icon name={this.props.icon || 'plus'} type="FontAwesome"
           style={[{color: Color.headerColor}, responsiveStyles.buttonIcon, this.props.buttonColor]}

--- a/app/components/OutlinedButton.js
+++ b/app/components/OutlinedButton.js
@@ -4,7 +4,7 @@ import { Button, Icon, Text } from 'native-base';
 import Color from '../themes/color';
 
 import { getDeviceStyle } from '../utils/responsive_util';
-import { pressableItemSize } from '../constants/components_size_constant';
+import { pressableItemSize } from '../utils/component_util';
 import OutlinedButtonTabletStyles from '../styles/tablet/OutlinedButtonComponentStyle';
 import OutlinedButtonMobileStyles from '../styles/mobile/OutlinedButtonComponentStyle';
 
@@ -17,7 +17,7 @@ class OutlinedButton extends Component {
         {...this.props}
         bordered
         iconLeft
-        style={{padding: 0, height: pressableItemSize}}
+        style={{padding: 0, height: pressableItemSize()}}
       >
         <Icon name={this.props.icon || 'plus'} type="FontAwesome"
           style={[{color: Color.headerColor}, responsiveStyles.buttonIcon, this.props.buttonColor]}

--- a/app/components/SaveButton.js
+++ b/app/components/SaveButton.js
@@ -8,8 +8,9 @@ const SaveButton = (props) => {
     <Button
       {...props}
       mode="contained"
-      style={{ marginLeft: 20 }}
-      labelStyle={{fontSize: normalLabelSize, paddingTop: 2, color: Color.whiteColor}}
+      style={{ marginLeft: 20, height: 51 }}
+      labelStyle={{fontSize: normalLabelSize, color: Color.whiteColor}}
+      contentStyle={{height: 51}}
     >
       {props.label}
     </Button>

--- a/app/components/SaveButton.js
+++ b/app/components/SaveButton.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Button } from 'react-native-paper';
 import { normalLabelSize } from '../utils/responsive_util';
+import { pressableItemSize } from '../utils/component_util';
+import { modalButtonPaddingVertical } from '../constants/component_style_constant';
 import Color from '../themes/color';
 
 const SaveButton = (props) => {
@@ -8,9 +10,9 @@ const SaveButton = (props) => {
     <Button
       {...props}
       mode="contained"
-      style={{ marginLeft: 20, height: 51 }}
+      style={{ marginLeft: 20, height: pressableItemSize(modalButtonPaddingVertical) }}
       labelStyle={{fontSize: normalLabelSize, color: Color.whiteColor}}
-      contentStyle={{height: 51}}
+      contentStyle={{height: pressableItemSize(modalButtonPaddingVertical)}}
     >
       {props.label}
     </Button>

--- a/app/config/environment.js
+++ b/app/config/environment.js
@@ -1,5 +1,5 @@
 export const environment = {
-  domain: 'http://192.168.0.103:3000',
+  domain: 'http://192.168.0.107:3000',
   type: 'development',
   defaultLanguage: 'km',
   removeScorecardDay: 90,

--- a/app/config/environment.js
+++ b/app/config/environment.js
@@ -1,5 +1,5 @@
 export const environment = {
-  domain: 'http://192.168.0.107:3000',
+  domain: 'http://192.168.0.103:3000',
   type: 'development',
   defaultLanguage: 'km',
   removeScorecardDay: 90,

--- a/app/constants/component_style_constant.js
+++ b/app/constants/component_style_constant.js
@@ -1,0 +1,1 @@
+export const modalButtonPaddingVertical = 3;

--- a/app/constants/components_size_constant.js
+++ b/app/constants/components_size_constant.js
@@ -1,1 +1,0 @@
-export const pressableItemSize = 48;

--- a/app/navigators/app_navigator.js
+++ b/app/navigators/app_navigator.js
@@ -38,7 +38,7 @@ import SettingMenu from '../components/Home/SettingMenu';
 import HeaderRightButton from '../components/HeaderRightButton';
 import { FontSize, FontFamily } from '../assets/stylesheets/theme/font';
 import { getDeviceStyle, mobileHeadingTitleSize } from '../utils/responsive_util';
-import { lgLabelSize } from '../constants/mobile_font_size_constant';
+import { pressableItemSize } from '../utils/component_util';
 
 const Stack = createStackNavigator();
 
@@ -63,7 +63,7 @@ function AppNavigator() {
         },
         headerTintColor: 'white',
         cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
-        headerLeft: () => <HeaderBackButton tintColor={Color.whiteColor} onPress={ () => navigationRef.current?.goBack() } style={{ width: 48, height: 48 }}/>
+        headerLeft: () => <HeaderBackButton tintColor={Color.whiteColor} onPress={ () => navigationRef.current?.goBack() } style={{ width: pressableItemSize(), height: pressableItemSize() }}/>
       }}>
       <Stack.Screen
         name="Home"

--- a/app/screens/FilterScorecard/FilterScorecard.js
+++ b/app/screens/FilterScorecard/FilterScorecard.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, ScrollView } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import AsyncStorage from '@react-native-community/async-storage';
 
@@ -121,7 +121,7 @@ class FilterScorecard extends Component {
         <ScrollView contentContainerStyle={{flexGrow: 1, paddingBottom: this.state.isSearchBoxFocused ? 300 : 20 }} stickyHeaderIndices={[2]}>
           { this.renderScorecardStatusAndTypeOptions() }
 
-          <Text style={{paddingHorizontal: 16, paddingVertical: 10, fontSize: getDeviceStyle(16, wp(mdLabelSize)), marginTop: 20, fontFamily: FontFamily.title, backgroundColor: Color.whiteColor, height: 49}}>
+          <Text style={{paddingHorizontal: 16, paddingVertical: 10, fontSize: getDeviceStyle(16, wp(mdLabelSize)), marginTop: 20, fontFamily: FontFamily.title, backgroundColor: Color.whiteColor}}>
             { translations.scorecardLocation }
           </Text>
 

--- a/app/styles/mobile/ButtonForgetCodeComponentStyle.js
+++ b/app/styles/mobile/ButtonForgetCodeComponentStyle.js
@@ -1,8 +1,8 @@
 import { StyleSheet } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import { mdLabelSize, smLabelSize } from '../../constants/mobile_font_size_constant';
-import { pressableItemSize } from '../../constants/components_size_constant';
 import { isShortScreenDevice } from '../../utils/responsive_util';
+import { pressableItemSize } from '../../utils/component_util';
 import Color from '../../themes/color';
 
 const ButtonForgetCodeComponentStyles = StyleSheet.create({
@@ -10,7 +10,7 @@ const ButtonForgetCodeComponentStyles = StyleSheet.create({
     alignItems: 'center',
     marginTop: isShortScreenDevice() ? 5 : 10,
     marginBottom: isShortScreenDevice() ? -wp('3%') : -wp('12%'),
-    height: pressableItemSize,
+    height: pressableItemSize(),
     justifyContent: 'center',
   },
   containerMarginBottom: {
@@ -19,9 +19,9 @@ const ButtonForgetCodeComponentStyles = StyleSheet.create({
   button: {
     flexDirection: 'row',
     alignItems: 'center',
-    padding: isShortScreenDevice() ? 0 : 10,
+    paddingHorizontal: isShortScreenDevice() ? 0 : 10,
     marginBottom: isShortScreenDevice() ? -10 : 0,
-    height: pressableItemSize,
+    height: pressableItemSize(),
   },
   icon: {
     color: Color.whiteColor,

--- a/app/styles/mobile/ButtonForgetCodeComponentStyle.js
+++ b/app/styles/mobile/ButtonForgetCodeComponentStyle.js
@@ -1,6 +1,7 @@
 import { StyleSheet } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import { mdLabelSize, smLabelSize } from '../../constants/mobile_font_size_constant';
+import { pressableItemSize } from '../../constants/components_size_constant';
 import { isShortScreenDevice } from '../../utils/responsive_util';
 import Color from '../../themes/color';
 
@@ -8,20 +9,28 @@ const ButtonForgetCodeComponentStyles = StyleSheet.create({
   container: {
     alignItems: 'center',
     marginTop: isShortScreenDevice() ? 5 : 10,
-    marginBottom: isShortScreenDevice() ? -wp('3%') : -wp('12%')
+    marginBottom: isShortScreenDevice() ? -wp('3%') : -wp('12%'),
+    height: pressableItemSize,
+    justifyContent: 'center',
+  },
+  containerMarginBottom: {
+    marginBottom: isShortScreenDevice() ? -wp('4%') : -wp('10%'),
   },
   button: {
     flexDirection: 'row',
     alignItems: 'center',
     padding: isShortScreenDevice() ? 0 : 10,
     marginBottom: isShortScreenDevice() ? -10 : 0,
+    height: pressableItemSize,
   },
   icon: {
     color: Color.whiteColor,
     fontSize: isShortScreenDevice() ? wp('4.5%') : wp('5.2%'),
+    marginTop: -8
   },
   label: {
     fontSize: isShortScreenDevice() ? wp(smLabelSize) : wp(mdLabelSize),
+    marginTop: -6
   }
 });
 

--- a/app/styles/mobile/NewScorecardScreenStyle.js
+++ b/app/styles/mobile/NewScorecardScreenStyle.js
@@ -7,7 +7,6 @@ import Color from '../../themes/color';
 
 const NewScorecardScreenStyles = StyleSheet.create({
   formContainer: {
-    // width: wp('77%'),
     width: wp('82%'),
     marginTop: 20,
   },

--- a/app/styles/mobile/NewScorecardScreenStyle.js
+++ b/app/styles/mobile/NewScorecardScreenStyle.js
@@ -7,7 +7,8 @@ import Color from '../../themes/color';
 
 const NewScorecardScreenStyles = StyleSheet.create({
   formContainer: {
-    width: wp('77%'),
+    // width: wp('77%'),
+    width: wp('82%'),
     marginTop: 20,
   },
   inputContainer: {

--- a/app/styles/mobile/ScorecardCodeInputComponentStyle.js
+++ b/app/styles/mobile/ScorecardCodeInputComponentStyle.js
@@ -2,6 +2,7 @@ import { StyleSheet } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import Color from '../../themes/color';
 import { mdLabelSize, xxlLabelSize } from '../../constants/mobile_font_size_constant';
+import { pressableItemSize } from '../../constants/components_size_constant';
 import { FontFamily } from '../../assets/stylesheets/theme/font';
 
 const ScorecardCodeInputComponentStyles = StyleSheet.create({
@@ -20,11 +21,8 @@ const ScorecardCodeInputComponentStyles = StyleSheet.create({
   inputContainer: {
     backgroundColor: Color.whiteColor,
     borderRadius: 4,
-    // width: wp('10%'),
-    // height: wp('11.7%'),
-    width: 48,
-    height: 48,
-
+    width: pressableItemSize,
+    height: pressableItemSize,
     textAlign: 'center',
     borderColor: Color.primaryColor,
     borderWidth: 1,

--- a/app/styles/mobile/ScorecardCodeInputComponentStyle.js
+++ b/app/styles/mobile/ScorecardCodeInputComponentStyle.js
@@ -15,13 +15,16 @@ const ScorecardCodeInputComponentStyles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginTop: 4
+    marginTop: 4,
   },
   inputContainer: {
     backgroundColor: Color.whiteColor,
     borderRadius: 4,
-    width: wp('10%'),
-    height: wp('11.7%'),
+    // width: wp('10%'),
+    // height: wp('11.7%'),
+    width: 48,
+    height: 48,
+
     textAlign: 'center',
     borderColor: Color.primaryColor,
     borderWidth: 1,

--- a/app/styles/mobile/ScorecardCodeInputComponentStyle.js
+++ b/app/styles/mobile/ScorecardCodeInputComponentStyle.js
@@ -2,8 +2,8 @@ import { StyleSheet } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import Color from '../../themes/color';
 import { mdLabelSize, xxlLabelSize } from '../../constants/mobile_font_size_constant';
-import { pressableItemSize } from '../../constants/components_size_constant';
 import { FontFamily } from '../../assets/stylesheets/theme/font';
+import { pressableItemSize } from '../../utils/component_util';
 
 const ScorecardCodeInputComponentStyles = StyleSheet.create({
   label: {
@@ -21,8 +21,8 @@ const ScorecardCodeInputComponentStyles = StyleSheet.create({
   inputContainer: {
     backgroundColor: Color.whiteColor,
     borderRadius: 4,
-    width: pressableItemSize,
-    height: pressableItemSize,
+    width: pressableItemSize(),
+    height: pressableItemSize(),
     textAlign: 'center',
     borderColor: Color.primaryColor,
     borderWidth: 1,

--- a/app/styles/tablet/ButtonForgetCodeComponentStyle.js
+++ b/app/styles/tablet/ButtonForgetCodeComponentStyle.js
@@ -1,15 +1,21 @@
 import { StyleSheet } from 'react-native';
 import Color from '../../themes/color';
+import { pressableItemSize } from '../../constants/components_size_constant';
 
 const ButtonForgetCodeComponentStyles = StyleSheet.create({
   container: {
     alignItems: 'center',
-    marginTop: 20
+    marginTop: 20,
+    height: pressableItemSize
+  },
+  containerMarginBottom: {
+    marginBottom: 0,
   },
   button: {
     flexDirection: 'row',
     alignItems: 'center',
     padding: 10,
+    height: pressableItemSize
   },
   icon: {
     color: Color.whiteColor,

--- a/app/styles/tablet/ButtonForgetCodeComponentStyle.js
+++ b/app/styles/tablet/ButtonForgetCodeComponentStyle.js
@@ -1,12 +1,12 @@
 import { StyleSheet } from 'react-native';
 import Color from '../../themes/color';
-import { pressableItemSize } from '../../constants/components_size_constant';
+import { pressableItemSize } from '../../utils/component_util';
 
 const ButtonForgetCodeComponentStyles = StyleSheet.create({
   container: {
     alignItems: 'center',
     marginTop: 20,
-    height: pressableItemSize
+    height: pressableItemSize()
   },
   containerMarginBottom: {
     marginBottom: 0,
@@ -14,8 +14,8 @@ const ButtonForgetCodeComponentStyles = StyleSheet.create({
   button: {
     flexDirection: 'row',
     alignItems: 'center',
-    padding: 10,
-    height: pressableItemSize
+    paddingHorizontal: 10,
+    height: pressableItemSize(),
   },
   icon: {
     color: Color.whiteColor,

--- a/app/styles/tablet/ScorecardCodeInputComponentStyle.js
+++ b/app/styles/tablet/ScorecardCodeInputComponentStyle.js
@@ -11,7 +11,8 @@ const ScorecardCodeInputComponentStyles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginTop: 4
+    marginTop: 4,
+    height: 55,
   },
   inputContainer: {
     backgroundColor: Color.whiteColor,

--- a/app/utils/component_util.js
+++ b/app/utils/component_util.js
@@ -1,0 +1,6 @@
+const defaultItemSize = 48;
+
+// receive the component padding (vertical or horizontal) as parameter
+export const pressableItemSize = (padding = 0) => {
+  return defaultItemSize + padding;
+}


### PR DESCRIPTION
This pull request is for improving the accessibility UI of the New Scorecard Screen by:
- Update the width and height of the text input to 48dp (for mobile devices)
- Update the height of the forget scorecard code button to 48dp
- Update the height of the buttons in the popup modal to 48dp
- Add the accessibility label to the button toggle password visibility of the authentication popup modal
[new scorecard screen.zip](https://github.com/ilabsea/scorecard_mobile/files/7683245/new.scorecard.screen.zip)

