### PR TITLE
make scorecard code bold in all popup message and increase the width …

### DIFF
--- a/app/components/FilterScorecard/LocationSearchBox.js
+++ b/app/components/FilterScorecard/LocationSearchBox.js
@@ -6,6 +6,7 @@ import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import Color from '../../themes/color';
 import { FontFamily } from '../../assets/stylesheets/theme/font';
 import { getDeviceStyle } from '../../utils/responsive_util';
+import { pressableItemSize } from '../../utils/component_util';
 import { mdLabelSize } from '../../constants/mobile_font_size_constant';
 
 import { LocalizationContext } from '../../components/Translations';
@@ -19,7 +20,7 @@ class LocationSearchBox extends Component {
 
     return (
       <View style={styles.container}>
-        <Item rounded style={[styles.inputContainer, this.props.searchedLocation ? { marginRight: 15 } : {}]}>
+        <Item rounded style={[styles.inputContainer, this.props.searchedLocation ? { marginRight: 10 } : {}]}>
           <Icon name="search" style={{fontSize: 22, paddingLeft: 10, paddingRight: 0, marginTop: 0, color: placeholderColor}} />
           <Input
             placeholder={ translations.searchLocation }
@@ -34,7 +35,7 @@ class LocationSearchBox extends Component {
         </Item>
 
         { !!this.props.searchedLocation &&
-          <TouchableOpacity onPress={() => this.props.onClearSearch()} style={{justifyContent: 'center'}}>
+          <TouchableOpacity onPress={() => this.props.onClearSearch()} style={{justifyContent: 'center', width: pressableItemSize(), alignItems: 'center'}}>
             <Icon name="close" style={{fontSize: 28, paddingLeft: 0, paddingRight: 0, marginTop: 0, color: Color.grayColor}} />
           </TouchableOpacity>
         }

--- a/app/components/NewScorecard/ScorecardProgressContent.js
+++ b/app/components/NewScorecard/ScorecardProgressContent.js
@@ -46,7 +46,7 @@ class ScorecardProgressContent extends Component {
 
         <View style={{marginTop: 15, paddingHorizontal: 22, flexDirection: 'row'}}>
           <Text style={responsiveStyles.label}>
-            {translations.formatString(translations.thisScorecardIsInStep, this.props.scorecardUuid)}
+            {translations.formatString(translations.thisScorecardIsInStep, <Text style={{fontWeight: 'bold'}}>{ this.props.scorecardUuid }</Text>)}
             <Text style={[{ fontFamily: FontFamily.title }, responsiveStyles.label]}> "{ translations[step.label] }"</Text>
           </Text>
         </View>

--- a/app/components/ScorecardList/ScorecardListModals.js
+++ b/app/components/ScorecardList/ScorecardListModals.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Text } from 'react-native';
 
 import MessageModal from '../MessageModal';
 import ErrorMessageModal from '../ErrorMessageModal/ErrorMessageModal';
@@ -10,9 +11,10 @@ class ScorecardListModals extends Component {
 
   render() {
     const { translations } = this.context;
+    const scorecardUuid = <Text style={{fontWeight: 'bold'}}>{ this.props.scorecardUuid }</Text>
     const modalMessage = this.props.isConfirmModal ?
-                          translations.formatString(translations.doYouWantToDeleteThisScorecard, this.props.scorecardUuid)
-                          : translations.formatString(translations.cannotDeleteThisScorecard, this.props.scorecardUuid);
+                          translations.formatString(translations.doYouWantToDeleteThisScorecard, scorecardUuid)
+                          : translations.formatString(translations.cannotDeleteThisScorecard, scorecardUuid);
 
     return (
       <React.Fragment>

--- a/app/components/ScorecardProgress/ScorecardProgressConfirmFinishContent.js
+++ b/app/components/ScorecardProgress/ScorecardProgressConfirmFinishContent.js
@@ -12,14 +12,15 @@ class ScorecardProgressConfirmFinishContent extends Component {
 
   render() {
     const { translations } = this.context;
+    const scorecardUuid = <Text style={{fontWeight: 'bold'}}>{ this.props.scorecardUuid }</Text>
 
     return (
       <View>
         <Text style={modalStyles.label}>
-          {translations.formatString(translations.thisScorecardWillBeLocked, this.props.scorecardUuid)}
+          {translations.formatString(translations.thisScorecardWillBeLocked, scorecardUuid)}
         </Text>
         <Text style={[{ marginTop: 12 }, , modalStyles.label]}>
-          {translations.formatString(translations.areYouSureYouWantToFinish, this.props.scorecardUuid)}
+          {translations.formatString(translations.areYouSureYouWantToFinish, scorecardUuid)}
         </Text>
       </View>
     )

--- a/app/screens/ScorecardResult/ScorecardResult.js
+++ b/app/screens/ScorecardResult/ScorecardResult.js
@@ -103,21 +103,6 @@ class ScorecardResult extends Component {
     this.props.navigation.reset({ index: 1, routes: [{ name: 'Home' }, {name: 'ScorecardList'}] });
   }
 
-  _confirmFinishContent = () => {
-    const {translations} = this.context;
-
-    return (
-      <View>
-        <Text style={modalStyles.label}>
-          {translations.formatString(translations.thisScorecardWillBeLocked, this.props.route.params.scorecard_uuid)}
-        </Text>
-        <Text style={[{ marginTop: 12 }, , modalStyles.label]}>
-          {translations.formatString(translations.areYouSureYouWantToFinish, this.props.route.params.scorecard_uuid)}
-        </Text>
-      </View>
-    )
-  }
-
   render() {
     const { translations } = this.context;
 


### PR DESCRIPTION
This pull request is enhancing the UI of all the popup message modals by making the scorecard code in the message bold. And set the width of the close search button in the Filter Scorecard screen to 48dp (reported by Google Play after uploading the new beta version 1.4.0). Below are the screenshots of the updated UI.
[enhanced UI.zip](https://github.com/ilabsea/scorecard_mobile/files/7710135/enhanced.UI.zip)
 