### PR TITLE
fix the endpoint of the mobile token api to be the same as the inputed endpoint in setting screen

### DIFF
--- a/app/api/MobileTokenApi.js
+++ b/app/api/MobileTokenApi.js
@@ -1,4 +1,5 @@
 import BaseApi from './BaseApi';
+import AsyncStorage from '@react-native-community/async-storage';
 import { environment } from '../config/environment';
 
 class MobileTokenApi extends BaseApi {
@@ -6,14 +7,16 @@ class MobileTokenApi extends BaseApi {
     super('mobile_tokens', '');
   }
 
-  put = (data) => {
+  put = async (data) => {
     const options = {
       url: '/api/v1/' + this.responsibleModel,
       method: 'PUT',
       data: data,
     };
 
-    return BaseApi.request(options, environment.domain);
+    const endpointUrl = await AsyncStorage.getItem('ENDPOINT_URL') || environment.domain;
+
+    return BaseApi.request(options, endpointUrl);
   }
 }
 


### PR DESCRIPTION
This pull request is fixing the endpoint that will use for sending the request for mobile token API. Originally, the endpoint is fixed (get from environment.js file). Now, the endpoint will change to the endpoint that the user inputs in the setting screen.