### PR TITLE
fix error invalid regular expression and udpate the condition when us…

### DIFF
--- a/app/services/deep_link_service.js
+++ b/app/services/deep_link_service.js
@@ -4,6 +4,7 @@ import AsyncStorage from '@react-native-community/async-storage';
 import newScorecardService from './new_scorecard_service';
 import { getErrorType } from './api_service';
 import Scorecard from '../models/Scorecard';
+import { isNumber, extractNumber } from '../utils/string_util';
 import scorecardProgress from '../db/jsons/scorecardProgress';
 import { ERROR_INCORRECT_SCORECARD_CODE } from '../constants/error_constant';
 
@@ -44,10 +45,13 @@ const deepLinkService = (() => {
   function _handleRedirection(url, updateModalStatus, closeModal, handleOccupiedScorecard) {
     const scorecardUuid = url.slice(-6);
     // If the last 6 digits include a special character or letter, shows an incorrect scorecard code message
-    if (!parseInt(scorecardUuid)) {
-      updateModalStatus(false, scorecardUuid.match(/\d|\./g).join(''), ERROR_INCORRECT_SCORECARD_CODE);
-      return;
+    if (!isNumber(scorecardUuid)) {
+      if (extractNumber(scorecardUuid) != '')
+        updateModalStatus(false, scorecardUuid, ERROR_INCORRECT_SCORECARD_CODE);
+
+      return;  
     }
+
     updateModalStatus(true, scorecardUuid, null);        // Show loading popup modal
 
     setTimeout(() => {

--- a/app/utils/scorecard_util.js
+++ b/app/utils/scorecard_util.js
@@ -1,6 +1,7 @@
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { getDeviceStyle, isShortWidthScreen } from './responsive_util';
+import { isNumber } from './string_util';
 import { validScorecardUrls } from '../constants/url_constant';
 import { ERROR_INVALID_SCORECARD_URL } from '../constants/error_constant';
 
@@ -51,7 +52,7 @@ export const handleScorecardCodeClipboard = async (updateErrorState) => {
   }
 
   copiedText = copiedText.slice(-6);
-  if (!parseInt(copiedText)) {    // if the last 6 digits contain a special character or letter
+  if (!isNumber(copiedText)) {    // if the last 6 digits contain a special character or letter
     _handelInvalidUrl(updateErrorState);
     return;
   }

--- a/app/utils/string_util.js
+++ b/app/utils/string_util.js
@@ -5,4 +5,13 @@ const isBlank = (value) => {
   return false;
 }
 
-export { isBlank }
+// Check if string contains only digits
+const isNumber = (value) => {
+  return /^\d+$/.test(value);
+}
+
+const extractNumber = (value) => {
+  return value.replace(/[^0-9]/g, '');
+}
+
+export { isBlank, isNumber, extractNumber }


### PR DESCRIPTION
This pull request is fixing the error message of invalid regular expression and updates the condition when the user copies or click on the invalid scorecard URL such as:
- Scorecard URL that doesn't contain the scorecard code
- Scorecard URL that contains the scorecard code with a special character or letter