### PR TITLE
Make no data message in edit indicator and search indindicator consis…

### DIFF
--- a/app/components/NoDataMessage.js
+++ b/app/components/NoDataMessage.js
@@ -13,16 +13,18 @@ class NoDataMessage extends Component {
   render() {
     return (
       <View style={[styles.container, this.props.customContainerStyle]}>
-        <View style={responsiveStyles.messageContainer}>
+        <View style={[responsiveStyles.messageContainer, this.props.contentContainerStyle]}>
           <Icon name={'document-outline'} style={responsiveStyles.icon} />
           <Text style={responsiveStyles.label}>{this.props.title}</Text>
-          <View>
-            <OutlinedButton
-              icon={ this.props.icon || 'plus' }
-              label={this.props.buttonLabel}
-              onPress={() => this.props.onPress() }
-            />
-          </View>
+          { !this.props.hideButton &&
+            <View>
+              <OutlinedButton
+                icon={ this.props.icon || 'plus' }
+                label={this.props.buttonLabel}
+                onPress={() => this.props.onPress() }
+              />
+            </View>
+          }
         </View>
       </View>
     );

--- a/app/components/RaisingProposed/CriteriaSelection.js
+++ b/app/components/RaisingProposed/CriteriaSelection.js
@@ -5,6 +5,7 @@ import {LocalizationContext} from '../Translations';
 import RaisingProposedScrollView from './RaisingProposedScrollView';
 import CriteriaSelectionItems from './CriteriaSelectionItems';
 import AddNewIndicatorButton from './AddNewIndicatorButton';
+import NoIndicatorMessage from './NoIndicatorMessage';
 
 import indicatorHelper from '../../helpers/indicator_helper';
 import createNewIndicatorHelper from '../../helpers/create_new_indicator_helper';
@@ -70,15 +71,19 @@ class CriteriaSelection extends Component {
   render() {
     return (
       <React.Fragment>
-        <RaisingProposedScrollView onScroll={(event) => this.onScroll(event)}>
-          <CriteriaSelectionItems
-            indicators={this.state.indicators}
-            selectedIndicators={this.state.selectedIndicators}
-            isSearching={this.props.isSearching}
-            scorecardUuid={this.props.scorecardUuid}
-            selectIndicator={this.selectIndicator}
-          />
-        </RaisingProposedScrollView>
+        { this.state.indicators.length > 0 &&
+          <RaisingProposedScrollView onScroll={(event) => this.onScroll(event)}>
+            <CriteriaSelectionItems
+              indicators={this.state.indicators}
+              selectedIndicators={this.state.selectedIndicators}
+              isSearching={this.props.isSearching}
+              scorecardUuid={this.props.scorecardUuid}
+              selectIndicator={this.selectIndicator}
+            />
+          </RaisingProposedScrollView>
+        }
+
+        { this.state.indicators.length === 0 && <NoIndicatorMessage /> }
 
         { !this.props.isSearching && this.renderAddNewIndicatorButton() }
       </React.Fragment>

--- a/app/components/RaisingProposed/NoIndicatorMessage.js
+++ b/app/components/RaisingProposed/NoIndicatorMessage.js
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+
+import {LocalizationContext} from '../Translations';
+import NoDataMessage from '../NoDataMessage';
+
+const NoIndicatorMessage = () => {
+  const locale = useContext(LocalizationContext);
+
+  return (
+    <NoDataMessage
+      title={locale.translations.noCustomIndicator}
+      hideButton={true}
+      contentContainerStyle={{height: 160, borderWidth: 0, marginTop: 20}}
+    />
+  )
+}
+
+export default NoIndicatorMessage;

--- a/app/components/RaisingProposed/RaisingProposedCustomIndicatorList.js
+++ b/app/components/RaisingProposed/RaisingProposedCustomIndicatorList.js
@@ -1,15 +1,9 @@
 import React, {Component} from 'react';
-import { Text } from 'react-native';
 
 import {LocalizationContext} from '../Translations';
 import RaisingProposedScrollView from './RaisingProposedScrollView';
 import CriteriaSelectionItems from './CriteriaSelectionItems';
-
-import { getDeviceStyle } from '../../utils/responsive_util';
-import NoDataMessageTabletStyles from '../../styles/tablet/NoDataMessageComponentStyle';
-import NoDataMessageMobileStyles from '../../styles/mobile/NoDataMessageComponentStyle';
-
-const responsiveStyles = getDeviceStyle(NoDataMessageTabletStyles, NoDataMessageMobileStyles);
+import NoIndicatorMessage from './NoIndicatorMessage';
 
 let _this = null;
 class RaisingProposedCustomIndicatorList extends Component {
@@ -40,19 +34,11 @@ class RaisingProposedCustomIndicatorList extends Component {
     )
   }
 
-  renderEmptyMessage() {
-    return (
-      <Text style={[responsiveStyles.label, {textAlign: 'center', marginTop: 0}]}>
-        { this.context.translations.noCustomIndicator }
-      </Text>
-    )
-  }
-
   render() {
     return (
       this.props.indicators.length > 0
         ? this.renderInidcatorList()
-        : this.renderEmptyMessage()
+        : <NoIndicatorMessage />
     )
   }
 }

--- a/app/screens/Setting/Setting.js
+++ b/app/screens/Setting/Setting.js
@@ -134,10 +134,10 @@ class Setting extends Component {
 
     const changeableSetting = await settingHelper.changeable(this.settingFormRef.current.state.backendUrl)
 
-    // if (!changeableSetting) {
-    //   this.setState({ visibleModal: true });
-    //   return;
-    // }
+    if (!changeableSetting) {
+      this.setState({ visibleModal: true });
+      return;
+    }
 
     if (!this.isValidForm()) {
       return;


### PR DESCRIPTION
This pull request is updating the message when there is no indicator to look consistent with the other screen.
[edit and search indicator.zip](https://github.com/ilabsea/scorecard_mobile/files/7801153/edit.and.search.indicator.zip)