### PR TITLE
fix alert URL incorrectly in joining scorecard screen

### DIFF
--- a/app/utils/scorecard_util.js
+++ b/app/utils/scorecard_util.js
@@ -42,8 +42,9 @@ export const getLocationMaxWidth = (scorecard) => {
 
 export const handleScorecardCodeClipboard = async (updateErrorState) => {
   let copiedText = await Clipboard.getString();
+  copiedText = copiedText.replace(' ', '');
 
-  if (copiedText == 'null')
+  if (copiedText == 'null' || copiedText == '')
     return;
 
   if (!_isValidScorecardUrl(copiedText)) {


### PR DESCRIPTION
This pull request is fixing the alert URL in the join scorecard screen. The alert URL keeps showing when the user standby device on the join scorecard screen without copying any text.