### PR TITLE
fix error when set focus on text input in join scorecard screen

### DIFF
--- a/app/components/NewScorecard/ScorecardCodeInput.js
+++ b/app/components/NewScorecard/ScorecardCodeInput.js
@@ -26,7 +26,7 @@ class ScorecardCodeInput extends Component {
     handleScorecardCodeClipboard(_this.props.handleInvalidUrl);
     AppState.addEventListener('change', this._handleAppStateChange);
     setTimeout(() => {
-      this.inputRef.focusField(0);
+      !!this.inputRef && this.inputRef.focusField(0);
     }, 5);
   }
 

--- a/app/components/RaisingProposed/Autocomplete.js
+++ b/app/components/RaisingProposed/Autocomplete.js
@@ -88,7 +88,7 @@ class Autocomplete extends Component {
           onClose={() => {
             this.onChangeText('');
             this.setState({tag: '', focusing: true});
-            this.tagInput.focus();
+            !!this.tagInput && this.tagInput.focus();
           }}
           textStyle={{fontSize: normalLabelSize, paddingTop: 4}}
           style={{ marginTop: 8, marginBottom: 2}}

--- a/app/screens/NewScorecard/NewScorecard.js
+++ b/app/screens/NewScorecard/NewScorecard.js
@@ -151,7 +151,7 @@ class NewScorecard extends Component {
     });
 
     if (hasAutoFocus && this.state.errorType != ERROR_INVALID_SCORECARD_URL)
-      this.scorecardRef.current.inputRef.focusField(5);
+      !!this.scorecardRef.current.inputRef && this.scorecardRef.current.inputRef.focusField(5);
   }
 
   renderForm() {

--- a/app/utils/scorecard_util.js
+++ b/app/utils/scorecard_util.js
@@ -47,7 +47,7 @@ export const handleScorecardCodeClipboard = async (updateErrorState) => {
   if (copiedText == 'null' || copiedText == '')
     return;
 
-  if (!_isValidScorecardUrl(copiedText)) {
+  if (!_isValidScorecardUrl(copiedText) && !isNumber(copiedText)) {
     _handelInvalidUrl(updateErrorState);
     return;
   }


### PR DESCRIPTION
This pull request is fixing the error that happened when setting the autofocus on the text input in the join scorecard screen by checking if the input ref is null before calling focus() or focusField(). And fixing the issue when the user copies only the scorecard code (number only) then it shows an invalid URL popup in the join scorecard screen.