### PR TITLE
prevent the error SERVICE_NOT_AVAILABLE when send request to get fire…

### DIFF
--- a/app/services/mobile_token_service.js
+++ b/app/services/mobile_token_service.js
@@ -2,9 +2,9 @@ import messaging from '@react-native-firebase/messaging';
 import AsyncStorage from '@react-native-community/async-storage';
 import NetInfo from '@react-native-community/netinfo';
 import MobileTokenApi from '../api/MobileTokenApi';
-import uuidv4 from '../utils/uuidv4';
 
 const TOKEN_KEY = 'registeredToken';
+const retryTime = 1;
 
 const MobileTokenService = (() => {
   return {
@@ -13,16 +13,7 @@ const MobileTokenService = (() => {
   }
 
   function handleSyncingToken() {
-    NetInfo.fetch().then(state => {
-      if (state.isConnected) {
-        messaging()
-          .getToken()
-          .then(token => {
-            console.log('== firebase token == ', token)
-            return handleToken(token);
-          });
-      }
-    });
+    _requestFirebaseToken(retryTime, (token) => handleToken(token));
 
     // // Listen to whether the token changes
     // return messaging().onTokenRefresh(token => {
@@ -46,41 +37,57 @@ const MobileTokenService = (() => {
 
   async function sendToken(token, id) {
     let data =  { mobile_token: {token: token, id: id} };
-    let Api = new MobileTokenApi();
-    Api.put(data)
-      .then(res => {
-        if(res.status == 200) {
-          saveToken(res.data);
-        }
-      });
+    _sendTokenToApi(data);
   }
 
   async function updateToken(program_id) {
     if (!program_id) return;
 
-    messaging()
-      .getToken()
-      .then(token => {
-        AsyncStorage.getItem(TOKEN_KEY, (error, storageToken) => {
-          let jsonValue = JSON.parse(storageToken) || {};
-          let data = { mobile_token: {token: token, id: jsonValue.id, program_id: program_id} };
-          let Api = new MobileTokenApi();
-
-          Api.put(data)
-            .then(res => {
-              if(res.status == 200) {
-                saveToken(res.data);
-              }
-            });
-        })
-      });
+    _requestFirebaseToken(retryTime, (token) => {
+      AsyncStorage.getItem(TOKEN_KEY, (error, storageToken) => {
+        let jsonValue = JSON.parse(storageToken) || {};
+        let data = { mobile_token: {token: token, id: jsonValue.id, program_id: program_id} };
+        _sendTokenToApi(data);
+      })
+    });
   }
 
-  async function saveToken(value) {
+  // private function
+
+  async function _saveToken(value) {
     try {
       await AsyncStorage.setItem(TOKEN_KEY, JSON.stringify(value));
     } catch (e) {
     }
+  }
+
+  function _requestFirebaseToken(count, callback) {
+    NetInfo.fetch().then(state => {
+      if (state.isConnected && state.isInternetReachable) {
+        messaging()
+          .getToken()
+          .then(token => {
+            callback(token);
+          })
+          .catch(error => {
+            if (count === 0)
+              return;
+
+            setTimeout(() => {
+              _requestFirebaseToken(count - 1, callback);
+            }, 2000);
+          });
+      }
+    });
+  }
+
+  function _sendTokenToApi(data) {
+    new MobileTokenApi().put(data)
+      .then(res => {
+        if(res.status == 200) {
+          _saveToken(res.data);
+        }
+      });
   }
 })();
 


### PR DESCRIPTION
This pull request is preventing the error of SERVICE_NOT_FOUND when sending the request to get a firebase token while the device has no internet connection. To prevent this error, we use the NetInfo to check if the device is connected and the internet is reachable with the currently active network connection (state.isInternetReachable) before sending the request. And apply a catch function to resend the request again (resend 1 time only) when it is failed to get the token.