### PR TITLE
apply check the internet reachable status in NetInfo before send requ…

### DIFF
--- a/app/components/Facilitator/FacilitatorReloadButton.js
+++ b/app/components/Facilitator/FacilitatorReloadButton.js
@@ -1,21 +1,48 @@
 import React, { Component } from 'react';
-
 import SyncDataButton from '../SyncDataButton';
 import { loadCaf } from '../../services/caf_service';
+import { ERROR_SOMETHING_WENT_WRONG } from '../../constants/error_constant';
 
 class FacilitatorReloadButton extends Component {
+  componentWillUnmount() {
+    this.isAbleToShowConnectionMessage = false;
+  }
+
   fetchFaciliators() {
     this.props.updateLoadingStatus(true);
+    this.isAbleToShowConnectionMessage = true;
+    this.isTimeout = false;
+
     loadCaf(this.props.localNgoId, (res, phase) => {
+      this.isAbleToShowConnectionMessage = false;
       this.props.reloadFacilitators();
       this.props.updateLoadingStatus(false);
     }, (error) => {
-      this.props.updateLoadingStatus(false);
+      if (!this.isTimeout) {
+        this.isAbleToShowConnectionMessage = false;
+        this.handleRequestError();
+      }
     });
   }
 
+  showSomethingWentWrong() {
+    if (this.isAbleToShowConnectionMessage) {
+      this.isTimeout = true;
+      this.handleRequestError();
+    }
+  }
+
+  handleRequestError() {
+    this.props.updateLoadingStatus(false);
+    this.props.showErrorMessage(ERROR_SOMETHING_WENT_WRONG);
+  }
+
   render() {
-    return <SyncDataButton syncData={() => this.fetchFaciliators()} />
+    return (
+      <SyncDataButton syncData={() => this.fetchFaciliators()}
+        showSomethingWentWrong={() => this.showSomethingWentWrong()}
+      />
+    )
   }
 }
 

--- a/app/components/ScorecardDetail/ScorecardDetailSyncButton.js
+++ b/app/components/ScorecardDetail/ScorecardDetailSyncButton.js
@@ -6,33 +6,60 @@ import SyncDataButton from '../SyncDataButton';
 import ScorecardService from '../../services/scorecardService';
 import {getErrorType} from '../../services/api_service';
 import Scorecard from '../../models/Scorecard';
-import { ERROR_SCORECARD } from '../../constants/error_constant';
+import { ERROR_SCORECARD, ERROR_SOMETHING_WENT_WRONG } from '../../constants/error_constant';
 
 class ScorecardDetailSyncButton extends Component {
   static contextType = LocalizationContext;
 
+  componentWillUnmount() {
+    this.isAbleToShowConnectionMessage = false;
+  }
+
   syncScorecardDetail() {
     const scorecardService = new ScorecardService();
     this.props.updateLoadingStatus(true);
+    this.isAbleToShowConnectionMessage = true;
+    this.isTimeout = false;
 
     scorecardService.find(this.props.scorecardUuid, (responseData) => {
-      if (responseData === null) {
+      if (responseData === null && !this.isTimeout) {
         // Show popup message when scorecard is not exist
-        this.props.updateLoadingStatus(false);
-        this.props.showErrorMessage(ERROR_SCORECARD);
+        this.isAbleToShowConnectionMessage = false;
+        this.handleRequestError(ERROR_SCORECARD);
       }
       else {
+        this.isAbleToShowConnectionMessage = false;
         Scorecard.upsert(responseData);
         this.props.finishSyncData();
       }
     }, (error) => {
-      this.props.updateLoadingStatus(false);
-      this.props.showErrorMessage(getErrorType(error.status));
+      if (!this.isTimeout) {
+        this.isAbleToShowConnectionMessage = false;
+        this.handleRequestError(getErrorType(error.status));
+      }
     });
   }
 
+  showSomethingWentWrong() {
+    if (this.isAbleToShowConnectionMessage) {
+      this.isTimeout = true;
+      this.handleRequestError(ERROR_SOMETHING_WENT_WRONG);
+    }
+  }
+
+  handleRequestError(errorType) {
+    this.props.updateLoadingStatus(false);
+    this.props.showErrorMessage(errorType);
+  }
+
   render() {
-    return <SyncDataButton syncData={() => this.syncScorecardDetail()} label={ DeviceInfo.isTablet() ? this.context.translations.syncInfo : '' } customStyle={{ marginRight: 9 }} />
+    return (
+      <SyncDataButton syncData={() => this.syncScorecardDetail()}
+        label={ DeviceInfo.isTablet() ? this.context.translations.syncInfo : '' }
+        customStyle={{ marginRight: 9 }}
+        showSomethingWentWrong={() => this.showSomethingWentWrong()}
+      />
+    )
   }
 }
 

--- a/app/components/ScorecardProgress/ScorecardProgressShareButton.js
+++ b/app/components/ScorecardProgress/ScorecardProgressShareButton.js
@@ -14,7 +14,7 @@ class ScorecardProgressShareButton extends Component {
 
   shareSubmittedScorecard() {
      NetInfo.fetch().then(state => {
-      if (state.isConnected) {
+      if (state.isConnected && state.isInternetReachable) {
         scorecardSharingService.shareScorecardPdfFile(this.props.scorecard.uuid, this.props.updateLoadingStatus, this.props.updateErrorMessageModal, this.context.appLanguage);
         return;
       }

--- a/app/components/SyncDataButton.js
+++ b/app/components/SyncDataButton.js
@@ -7,13 +7,23 @@ import Color from '../themes/color';
 import { LocalizationContext } from './Translations'
 import { pressableItemSize } from '../utils/component_util';
 import internetConnectionService from '../services/internet_connection_service';
+import {checkConnection} from '../services/api_service';
 
 class SyncDataButton extends Component {
   static contextType = LocalizationContext;
 
   onPress() {
     NetInfo.fetch().then(state => {
-      state.isConnected ? this.props.syncData() : internetConnectionService.showAlertMessage(this.context.translations.noInternetConnection)
+      if (state.isConnected && state.isInternetReachable) {
+        this.props.syncData();
+
+        // If the sync request is taking too long (20 seconds), it will show a something when wrong message
+        checkConnection((type, message) => {
+          this.props.showSomethingWentWrong();
+        });
+      }
+      else
+        internetConnectionService.showAlertMessage(this.context.translations.noInternetConnection)
     });
   }
 

--- a/app/screens/Facilitator/Facilitator.js
+++ b/app/screens/Facilitator/Facilitator.js
@@ -7,6 +7,7 @@ import ProgressHeader from '../../components/ProgressHeader';
 import BottomButton from '../../components/BottomButton';
 import FacilitatorForm from '../../components/Facilitator/FacilitatorForm';
 import FacilitatorReloadButton from '../../components/Facilitator/FacilitatorReloadButton';
+import ErrorMessageModal from '../../components/ErrorMessageModal/ErrorMessageModal';
 import Caf from '../../models/Caf';
 import facilitatorService from '../../services/facilitator_service';
 import scorecardTracingStepsService from '../../services/scorecard_tracing_steps_service';
@@ -26,6 +27,8 @@ class FacilitatorScreen extends Component {
       isError: true,
       containerPaddingBottom: 0,
       isLoading: false,
+      modalVisible: false,
+      errorType: null,
     };
 
     this.formRef = React.createRef();
@@ -90,6 +93,16 @@ class FacilitatorScreen extends Component {
     );
   };
 
+  renderErrorMessageModal() {
+    return (
+      <ErrorMessageModal
+        visible={this.state.modalVisible}
+        onDismiss={() => this.setState({ modalVisible: false })}
+        errorType={this.state.errorType}
+        isNewScorecard={true}
+      />
+    )
+  }
 
   render() {
     const {translations} = this.context;
@@ -104,6 +117,7 @@ class FacilitatorScreen extends Component {
               <FacilitatorReloadButton localNgoId={this.props.route.params.local_ngo_id}
                 reloadFacilitators={() => this.loadFacilitators()}
                 updateLoadingStatus={(status) => this.setState({ isLoading: status })}
+                showErrorMessage={(errorType) => this.setState({ modalVisible: true, errorType })}
               />
             }
           />
@@ -135,6 +149,8 @@ class FacilitatorScreen extends Component {
           </KeyboardAvoidingView>
 
           { this.renderNextButton() }
+
+          { this.renderErrorMessageModal() }
         </View>
       </TouchableWithoutFeedback>
     );

--- a/app/services/scorecard_sync_service.js
+++ b/app/services/scorecard_sync_service.js
@@ -18,7 +18,7 @@ const scorecardSyncService = (() => {
       return;
 
     NetInfo.fetch().then(state => {
-      if (state.isConnected) {
+      if (state.isConnected && state.isInternetReachable) {
         _syncAndUpdateScorecard(scorecardUuid);
       }
     });


### PR DESCRIPTION
This pull request is checking the internet reachable status in NetInfo before sending the request to API. And handle when syncing the data in scorecard detail and facilitator screen, if the sync data request is taking too long (20 sec) then hide the loading and show a "something went wrong" message. Below are the screenshots of the "something went wrong" message in the scorecard detail and facilitator screen.
[scorecard detail and  facilitator screen.zip](https://github.com/ilabsea/scorecard_mobile/files/7867828/scorecard.detail.and.facilitator.screen.zip)

