### PR TITLE
Pull down on scorecard progress screen to sync the scorecard status

### DIFF
--- a/app/components/PullToRefreshScrollView.js
+++ b/app/components/PullToRefreshScrollView.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ScrollView, RefreshControl } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
+
+import { LocalizationContext } from './Translations';
+import internetConnectionService from '../services/internet_connection_service';
+
+class PullToRefreshScrollView extends React.Component {
+  static contextType = LocalizationContext;
+
+  syncData() {
+    NetInfo.fetch().then(state => {
+      if (state.isConnected && state.isInternetReachable) {
+        this.props.updateLoadingState(true);
+        this.props.syncData();
+      }
+      else
+        internetConnectionService.showAlertMessage(this.context.translations.noInternetConnection,);
+    });
+  }
+
+  render() {
+    return (
+      <ScrollView
+        contentContainerStyle={this.props.containerStyle}
+        stickyHeaderIndices={this.props.stickyIndices}
+        refreshControl={
+          <RefreshControl
+            enabled={this.props.allowPullToRefresh}
+            refreshing={this.props.isLoading}
+            onRefresh={() => this.syncData()}
+          />
+        }
+      >
+        { this.props.children }
+      </ScrollView>
+    )
+  }
+}
+
+export default PullToRefreshScrollView;

--- a/app/components/ScorecardProgress/ScorecardProgressScrollView.js
+++ b/app/components/ScorecardProgress/ScorecardProgressScrollView.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import PullToRefreshScrollView from '../PullToRefreshScrollView';
+import VerticalProgressStep from './VerticalProgressStep';
+import ScorecardProgressTitle from './ScorecardProgressTitle';
+import scorecardSyncService from '../../services/scorecard_sync_service';
+import { isScorecardInReview } from '../../utils/scorecard_util';
+import { getDeviceStyle } from '../../utils/responsive_util';
+import ScorecardProgressTabletStyles from '../../styles/tablet/ScorecardProgressScreenStyle';
+import ScorecardProgressMobileStyles from '../../styles/mobile/ScorecardProgressScreenStyle';
+
+const responsiveStyles = getDeviceStyle(ScorecardProgressTabletStyles, ScorecardProgressMobileStyles);
+
+class ScorecardProgressScrollView extends React.Component {
+  state = { isLoading: false };
+
+  syncScorecard() {
+    scorecardSyncService.syncScorecard(this.props.scorecard.uuid, (scorecard) => {
+      this.setState({ isLoading: false });
+      this.props.updateScorecard(scorecard);
+    });
+  }
+
+  render() {
+    return (
+      <PullToRefreshScrollView
+        containerStyle={responsiveStyles.container}
+        allowPullToRefresh={isScorecardInReview(this.props.scorecard)}
+        syncData={() => this.syncScorecard()}
+        isLoading={this.state.isLoading}
+        updateLoadingState={(isLoading) => this.setState({ isLoading })}
+      >
+        <ScorecardProgressTitle scorecard={this.props.scorecard} />
+
+        <VerticalProgressStep
+          progressIndex={this.props.scorecard.status || 3}
+          scorecard={this.props.scorecard}
+        />
+      </PullToRefreshScrollView>
+    )
+  }
+}
+
+export default ScorecardProgressScrollView;

--- a/app/components/ScorecardProgress/VerticalProgressStep.js
+++ b/app/components/ScorecardProgress/VerticalProgressStep.js
@@ -10,6 +10,7 @@ import Color from '../../themes/color';
 import uuidv4 from '../../utils/uuidv4';
 import MilestoneCard from './MilestoneCard';
 import ScorecardStep from '../../models/ScorecardStep';
+import { navigate } from '../../navigators/app_navigator';
 
 import { getDeviceStyle } from '../../utils/responsive_util';
 
@@ -19,7 +20,7 @@ export default class VerticalProgressStep extends Component {
   static contextType = LocalizationContext;
 
   onPress(step) {
-    this.props.navigation.navigate(step.routeName, { scorecard_uuid: this.props.scorecard.uuid, local_ngo_id: this.props.scorecard.local_ngo_id })
+    navigate(step.routeName, { scorecard_uuid: this.props.scorecard.uuid, local_ngo_id: this.props.scorecard.local_ngo_id });
   }
 
   _renderMilestoneCard(step) {

--- a/app/models/Scorecard.js
+++ b/app/models/Scorecard.js
@@ -30,10 +30,12 @@ const Scorecard = (() => {
     return realm.objects('Scorecard').filtered(`uuid='${uuid}'`)[0];
   }
 
-  function update(uuid, params={}) {
+  function update(uuid, params={}, callback = null) {
     if (find(uuid)) {
       realm.write(() => {
         realm.create('Scorecard', Object.assign(params, {uuid: uuid}), 'modified');
+
+        !!callback && callback(find(uuid));
       })
     }
   }

--- a/app/screens/ScorecardProgress/ScorecardProgress.js
+++ b/app/screens/ScorecardProgress/ScorecardProgress.js
@@ -1,13 +1,12 @@
 import React, {Component} from 'react';
-import { View, ScrollView } from 'react-native';
+import { View } from 'react-native';
 import Spinner from 'react-native-loading-spinner-overlay';
 
 import { LocalizationContext } from '../../components/Translations';
-import VerticalProgressStep from '../../components/ScorecardProgress/VerticalProgressStep';
 import ErrorMessageModal from '../../components/ErrorMessageModal/ErrorMessageModal';
-import ScorecardProgressTitle from '../../components/ScorecardProgress/ScorecardProgressTitle';
 import ScorecardProgressButtons from '../../components/ScorecardProgress/ScorecardProgressButtons';
 import ScorecardProgressHeader from '../../components/ScorecardProgress/ScorecardProgressHeader';
+import ScorecardProgressScrollView from '../../components/ScorecardProgress/ScorecardProgressScrollView';
 
 import Color from '../../themes/color';
 import ScorecardService from '../../services/scorecardService';
@@ -17,11 +16,6 @@ import Scorecard from '../../models/Scorecard';
 import { ERROR_SUBMIT_SCORECARD } from '../../constants/error_constant';
 
 import { connect } from 'react-redux';
-import { getDeviceStyle } from '../../utils/responsive_util';
-import ScorecardProgressTabletStyles from '../../styles/tablet/ScorecardProgressScreenStyle';
-import ScorecardProgressMobileStyles from '../../styles/mobile/ScorecardProgressScreenStyle';
-
-const responsiveStyles = getDeviceStyle(ScorecardProgressTabletStyles, ScorecardProgressMobileStyles);
 
 class ScorecardProgress extends Component {
   static contextType = LocalizationContext;
@@ -126,15 +120,9 @@ class ScorecardProgress extends Component {
 
         <Spinner visible={this.state.isLoading} color={Color.primaryColor} overlayColor={Color.loadingBackgroundColor} />
 
-        <ScrollView contentContainerStyle={responsiveStyles.container}>
-          <ScorecardProgressTitle scorecard={this.state.scorecard} />
-
-          <VerticalProgressStep
-            progressIndex={this.state.scorecard.status || 3}
-            scorecard={this.state.scorecard}
-            navigation={this.props.navigation}
-          />
-        </ScrollView>
+        <ScorecardProgressScrollView scorecard={this.state.scorecard}
+          updateScorecard={(scorecard) => this.setState({ scorecard }) }
+        />
 
         <ScorecardProgressButtons
           scorecard={this.state.scorecard}


### PR DESCRIPTION
This pull request is applying pull to sync the scorecard status in the scorecard progress screen.
- If the scorecard has status IN-REVIEW, then LNGO updated the scorecard to COMPLETED on the server-side. The user will be able to pull down to sync the scorecard status to COMPLETED and be able to share the scorecard PDF.

- If the scorecard doesn't have status IN-REVIEW, then the user will not be able to pull down to sync the scorecard status.
![scorecard progress screen](https://user-images.githubusercontent.com/18114944/150957245-7b22e40f-b89c-4772-b063-50e80e0ca0a9.jpg)

