### PR TITLE
Remove the youth checkbox from the add new participant screen and form

### DIFF
--- a/app/components/AddNewParticipant/ParticipantForm.js
+++ b/app/components/AddNewParticipant/ParticipantForm.js
@@ -57,11 +57,6 @@ class ParticipantForm extends Component {
         { iconName: 'wheelchair', fieldName: 'isDisability', isSelected: this.state.isDisability, title: translations.disability },
         { iconName: 'users', fieldName: 'isMinority', isSelected: this.state.isMinority, title: translations.minority },
         { iconName: 'id-card', fieldName: 'isPoor', isSelected: this.state.isPoor, title: translations.poor },,
-      ],
-      secondRow: [
-        { iconName: 'universal-access', fieldName: 'isYouth', isSelected: this.state.isYouth, title: translations.youth },
-        null,
-        null,
       ]
     }
 

--- a/app/services/authentication_service.js
+++ b/app/services/authentication_service.js
@@ -52,10 +52,7 @@ const authenticationService = (() => {
     const setting = await AsyncStorage.getItem('SETTING');
     const { email, password } = JSON.parse(setting);
 
-    authenticate(email, password, (responseData) => {
-      AsyncStorage.setItem('TOKEN_EXPIRED_DATE', responseData.token_expired_date);
-      AsyncStorage.setItem('AUTH_TOKEN', responseData.authentication_token);
-      authenticationFormService.clearErrorAuthentication();
+    authenticate(email, password, () => {
       callback();
     }, (error) => {
       AsyncStorage.removeItem('AUTH_TOKEN');


### PR DESCRIPTION
This pull request is removing the Youth checkbox from the add/edit participant form in the add new participant screen and popup modal. Because the youth value is automatically calculated by the age of the participant and the user is not able to manually toggle the checkbox, we decided to remove the Youth checkbox from the form, but the youth data is still recorded as normal.