### PR TITLE
Add validation to use a unique name when creating or editing custom i…

### DIFF
--- a/app/components/RaisingProposed/AddNewIndicatorModal.js
+++ b/app/components/RaisingProposed/AddNewIndicatorModal.js
@@ -14,6 +14,7 @@ import { LocalizationContext } from '../Translations';
 import AddNewIndicatorModalTextInputs from './AddNewIndicatorModalTextInputs';
 import AddNewIndicatorModalButtons from './AddNewIndicatorModalButtons';
 
+import IndicatorService from '../../services/indicator_service';
 import customIndicatorService from '../../services/custom_indicator_service';
 import { FontFamily } from '../../assets/stylesheets/theme/font';
 import { modalHeadingTitleSize } from '../../utils/responsive_util';
@@ -30,6 +31,7 @@ class AddNewIndicatorModal extends Component {
       name: '',
       tag: '',
       audio: null,
+      isIndicatorExist: false,
     };
 
     this.isComponentUnmount = false;
@@ -54,6 +56,7 @@ class AddNewIndicatorModal extends Component {
       name: '',
       tag: '',
       audio: null,
+      isIndicatorExist: false,
     });
     this.props.closeModal();
   }
@@ -89,7 +92,17 @@ class AddNewIndicatorModal extends Component {
   }
 
   renderButtons = () => {
-    return <AddNewIndicatorModalButtons name={this.state.name} save={() => this.save()} cancel={() => this.cancel()} />
+    return <AddNewIndicatorModalButtons name={this.state.name} save={() => this.save()}
+            cancel={() => this.cancel()} isIndicatorExist={this.state.isIndicatorExist} />
+  }
+
+  onChangeName(name) {
+    const selectedIndicatorUuid = this.props.selectedCustomIndicator ? this.props.selectedCustomIndicator.uuid : null;
+
+    this.setState({
+      name,
+      isIndicatorExist: name === '' ? false : new IndicatorService().isIndicatorExist(this.props.scorecardUUID, name, selectedIndicatorUuid),
+    });
   }
 
   renderTextInputs() {
@@ -99,8 +112,9 @@ class AddNewIndicatorModal extends Component {
         tag={this.state.tag}
         isEdit={this.props.isEdit}
         scorecardUuid={this.props.scorecardUUID}
-        onChangeName={(text) => this.setState({name: text})}
+        onChangeName={(text) => this.onChangeName(text)}
         onChangeTag={(text) => this.setState({tag: text})}
+        isIndicatorExist={this.state.isIndicatorExist}
       />
     )
   }

--- a/app/components/RaisingProposed/AddNewIndicatorModalButtons.js
+++ b/app/components/RaisingProposed/AddNewIndicatorModalButtons.js
@@ -10,7 +10,7 @@ class AddNewIndicatorModalButtons extends Component {
   static contextType = LocalizationContext;
 
   isValid = () => {
-    if (isBlank(this.props.name))
+    if (isBlank(this.props.name) || this.props.isIndicatorExist)
       return false;
 
     return true;

--- a/app/components/RaisingProposed/AddNewIndicatorModalTextInputs.js
+++ b/app/components/RaisingProposed/AddNewIndicatorModalTextInputs.js
@@ -35,6 +35,7 @@ class AddNewIndicatorModalTextInputs extends Component {
           placeholder={translations.enterIndicatorName}
           fieldName="indicatorName"
           onChangeText={(fieldName, text) => this.props.onChangeName(text)}
+          message={this.props.isIndicatorExist ? translations.thisIndicatorIsAlreadyExist : ''}
         />
 
         <Autocomplete

--- a/app/helpers/indicator_helper.js
+++ b/app/helpers/indicator_helper.js
@@ -2,6 +2,7 @@ import IndicatorService from '../services/indicator_service';
 import CustomIndicator from '../models/CustomIndicator';
 import { find as findLanguageIndicator } from '../services/language_indicator_service';
 import Scorecard from '../models/Scorecard';
+import Indicator from '../models/Indicator';
 
 const indicatorHelper = (() => {
   return {
@@ -38,8 +39,7 @@ const indicatorHelper = (() => {
   }
 
   function isExist(indicatorId) {
-    const indicator = new IndicatorService().find(indicatorId);
-    return indicator === undefined ? false : true;
+    return Indicator.find(indicatorId) === undefined ? false : true;
   }
 
   function getDisplayIndicator(indicatorable, scorecardObj) {
@@ -70,7 +70,7 @@ const indicatorHelper = (() => {
   // Private
 
   function _getPredefinedIndicator(indicatorable, scorecard) {
-    let predefined = new IndicatorService().find(indicatorable.indicatorable_id);
+    let predefined = Indicator.find(indicatorable.indicatorable_id);
     let indi = findLanguageIndicator(indicatorable.indicatorable_id, scorecard.audio_language_code);
     indi = indi || predefined;
     indi = JSON.parse(JSON.stringify(indi));

--- a/app/localization/en.json
+++ b/app/localization/en.json
@@ -308,5 +308,6 @@
   "syncInfo": "Sync info",
   "inReview": "in review",
   "theServerUrlIsInvalid": "The server URL is invalid",
-  "yourDeviceIsCurrentlyLocked": "Your device is currently locked, please try again at {0}"
+  "yourDeviceIsCurrentlyLocked": "Your device is currently locked, please try again at {0}",
+  "thisIndicatorIsAlreadyExist": "This indicator is already exist"
 }

--- a/app/localization/km.json
+++ b/app/localization/km.json
@@ -308,5 +308,6 @@
   "syncInfo": "ធ្វើបច្ចុប្បន្នភាព",
   "inReview": "កំពុងត្រួតពិនិត្យ",
   "theServerUrlIsInvalid": "អាស័យដ្ឋានម៉ាស៊ីនមេមិនត្រឹមត្រូវ",
-  "yourDeviceIsCurrentlyLocked": "ឧបករណ៍របស់អ្នកត្រូវបានជាប់សោ។ សូមព្យាយាមម្ដងទៀតនៅម៉ោង {0}"
+  "yourDeviceIsCurrentlyLocked": "ឧបករណ៍របស់អ្នកត្រូវបានជាប់សោ។ សូមព្យាយាមម្ដងទៀតនៅម៉ោង {0}",
+  "thisIndicatorIsAlreadyExist": "លក្ខណៈវិនិច្ឆ័យនេះមានរួចហើយ"
 }

--- a/app/models/CustomIndicator.js
+++ b/app/models/CustomIndicator.js
@@ -2,6 +2,8 @@ import realm from '../db/schema';
 import AsyncStorage from '@react-native-community/async-storage';
 import RNFS from 'react-native-fs';
 
+const MODEL = 'CustomIndicator';
+
 const CustomIndicator = (() => {
   return {
     find,
@@ -11,32 +13,33 @@ const CustomIndicator = (() => {
     filter,
     create,
     deleteFile,
+    isNameExist,
   }
 
   function getAll(scorecardUuid) {
-    return realm.objects('CustomIndicator').filtered(`scorecard_uuid='${scorecardUuid}'`);
+    return realm.objects(MODEL).filtered(`scorecard_uuid='${scorecardUuid}'`);
   }
 
   function find(uuid) {
-    return realm.objects('CustomIndicator').filtered(`uuid='${uuid}'`)[0];
+    return realm.objects(MODEL).filtered(`uuid='${uuid}'`)[0];
   }
 
   function create(data) {
     realm.write(() => {
-      realm.create('CustomIndicator', data, 'modified');
+      realm.create(MODEL, data, 'modified');
     });
   }
 
   function update(uuid, params) {
     if (find(uuid)) {
       realm.write(() => {
-        realm.create('CustomIndicator', Object.assign(params, {uuid: uuid}), 'modified');
+        realm.create(MODEL, Object.assign(params, {uuid: uuid}), 'modified');
       })
     }
   }
 
   function deleteAll(scorecardUuid) {
-    const customIndicators = realm.objects('CustomIndicator').filtered(`scorecard_uuid = '${scorecardUuid}'`);
+    const customIndicators = realm.objects(MODEL).filtered(`scorecard_uuid = '${scorecardUuid}'`);
 
     if (customIndicators.length > 0) {
       realm.write(() => {
@@ -47,7 +50,7 @@ const CustomIndicator = (() => {
   }
 
   function filter(scorecardUuid, text) {
-    return realm.objects('CustomIndicator').filtered(`scorecard_uuid = '${scorecardUuid}' AND (name CONTAINS[c] '${text}' OR tag CONTAINS[c] '${text}')`);
+    return realm.objects(MODEL).filtered(`scorecard_uuid = '${scorecardUuid}' AND (name CONTAINS[c] '${text}' OR tag CONTAINS[c] '${text}')`);
   }
 
   function deleteFile(filePath) {
@@ -68,6 +71,10 @@ const CustomIndicator = (() => {
       .catch((err) => {
         console.log(err.message);
       });
+  }
+
+  function isNameExist(scorecardUuid, name, selectedIndicatorUuid) {
+    return realm.objects(MODEL).filtered(`scorecard_uuid = '${ scorecardUuid }' AND uuid != '${selectedIndicatorUuid}' AND name ==[c] '${ name }'`).length > 0 ? true : false;
   }
 
   // Private method

--- a/app/models/Indicator.js
+++ b/app/models/Indicator.js
@@ -2,22 +2,49 @@ import realm from '../db/schema';
 import Scorecard from './Scorecard';
 import CustomIndicator from './CustomIndicator';
 
+const  MODEL = 'Indicator';
+
 const Indicator = (() => {
   return {
+    find,
+    create,
     filter,
+    findByScorecard,
+    isNameExist,
   };
+
+  function find(id) {
+    return realm.objects('Indicator').filtered(`id = ${id}`)[0];
+  }
+
+  function create(data) {
+    realm.write(() => {
+      realm.create(MODEL, data, 'modified');
+    });
+  }
 
   // Filter predefinded and custom indicator by name or tag
   function filter(scorecardUuid, text) {
 
     const facilityId = Scorecard.find(scorecardUuid).facility_id;
-    let indicators = realm.objects('Indicator').filtered(`facility_id = '${facilityId}' AND (name CONTAINS[c] '${text}' OR tag CONTAINS[c] '${text}')`);
+    let indicators = realm.objects(MODEL).filtered(`facility_id = '${facilityId}' AND (name CONTAINS[c] '${text}' OR tag CONTAINS[c] '${text}')`);
     const customIndicators = CustomIndicator.filter(scorecardUuid, text);
 
     if (customIndicators.length > 0)
       indicators = [...indicators, ...customIndicators];
 
     return indicators;
+  }
+
+  function findByScorecard(scorecardUuid) {
+    const facilityId = Scorecard.find(scorecardUuid).facility_id;
+    return realm.objects(MODEL).filtered(`facility_id = '${facilityId}'`);
+  }
+
+  function isNameExist(scorecardUuid, name) {
+    const facilityId = Scorecard.find(scorecardUuid).facility_id;
+    const indicators = realm.objects(MODEL).filtered(`facility_id = '${facilityId}' AND name ==[c] '${name}'`);
+    return indicators.length > 0 ? true : false;
   }
 })();
 

--- a/app/services/scorecard_download_service.js
+++ b/app/services/scorecard_download_service.js
@@ -176,22 +176,6 @@ const _downloadIndicator = (scorecard, audioLocale, updateDownloadProgress, erro
   );
 }
 
-const _downloadIndicatorImage = (scorecard, audioLocale, updateDownloadProgress, errorCallback) => {
-  _indicatorService.saveImage(scorecard.uuid,
-    (isDownloaded, phase) => {
-      const options = {
-        isDownloaded,
-        phase,
-        scorecard,
-        audioLocale,
-      };
-
-      _downloadSuccess(options, updateDownloadProgress, errorCallback, downloadLangIndicatorAudio);
-    },
-    errorCallback
-  );
-}
-
 const downloadLangIndicatorAudio = (scorecard, audioLocale, updateDownloadProgress, errorCallback) => {
   if (!_languageIndicatorService)
     _languageIndicatorService = new LanguageIndicatorService();
@@ -255,7 +239,6 @@ const stopDownload = () => {
   if (_indicatorService) {
     _languageIndicatorService.stopDownload()
     _languageRatingScaleService.stopDownload();
-    _indicatorService.stopDownload();
   }
 
   _languageIndicatorService = null;


### PR DESCRIPTION
This pull request is adding validation when creating or editing the custom indicator. The user cannot create or edit the custom indicator to have the same name as the predefined indicator or the same name as the other existing custom indicator.

Below are the screenshots of the error message when the user inputted the indicator name the same as the existing indicator.
[Validate custom indicator.zip](https://github.com/ilabsea/scorecard_mobile/files/7993749/Validate.custom.indicator.zip)

