### PR TITLE
prevent font scaling when user changes the font size of the device

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,6 @@
 import 'react-native-gesture-handler';
 import React, { useEffect, useContext, useState } from 'react';
-import { AppState } from 'react-native';
+import { AppState, Text, TextInput } from 'react-native';
 import * as Sentry from '@sentry/react-native';
 import SplashScreen from 'react-native-splash-screen';
 import AsyncStorage from '@react-native-community/async-storage'; // 1
@@ -47,6 +47,12 @@ const theme = {
     thin: { fontFamily: FontFamily.body }
   }
 };
+
+Text.defaultProps = Text.defaultProps || {};
+Text.defaultProps.allowFontScaling = false;
+
+TextInput.defaultProps = TextInput.defaultProps || {};
+TextInput.defaultProps.allowFontScaling = false;
 
 const App: () => React$Node = () => {
   const [ loading, setLoading ] = useState(true);


### PR DESCRIPTION
This pull request is preventing the font size of the app from scaling up or down when the user changes the font size of the device in the display setting.
![device-font-size-setting](https://user-images.githubusercontent.com/18114944/152720292-e14d5f38-5183-4b9a-b548-04a7c340f079.jpg)

