### PR TITLE
Fix the error of AsyncStorage for passing null/undefined as value

### DIFF
--- a/app/components/ErrorMessageModal/ErrorMessageModal.js
+++ b/app/components/ErrorMessageModal/ErrorMessageModal.js
@@ -27,8 +27,9 @@ class ErrorMessageModal extends Component {
 
   async componentDidMount() {
     const setting = await AsyncStorage.getItem('SETTING');
+
     this.setState({
-      backendUrl: setting != null ? JSON.parse(setting).backendUrl : environment.defaultEndpoint,
+      backendUrl: (setting != null && !!JSON.parse(setting).backendUrl) ? JSON.parse(setting).backendUrl : environment.defaultEndpoint,
     }, () => {
       AsyncStorage.setItem('ENDPOINT_URL', this.state.backendUrl);
     });


### PR DESCRIPTION
This pull request is fixing the error that happened when passing the null ENDPOINT_URL to the AsyncStorage. It happened when the app is freshly installed and the user tries to join the scorecard without login.