### PR TITLE
Change the icon of the submitted scorecard that isn't approved to che…

### DIFF
--- a/app/helpers/scorecard_helper.js
+++ b/app/helpers/scorecard_helper.js
@@ -57,7 +57,7 @@ const scorecardHelper = (() => {
     const milestoneIcons = {
       finished: { name: 'check', color: Color.successColor },
       submitted: { name: 'lock', color: Color.lightGrayColor },
-      in_review: { name: 'lock', color: Color.lightGrayColor },
+      in_review: { name: 'check', color: Color.lightGrayColor },
       default: { name: 'hourglass-half', color: scorecardTypeColor(scorecard) }
     };
 


### PR DESCRIPTION
This pull request is updating the icon of the scorecard submitted scorecard that is not approved yet on the scorecard list screen.
Icon of the scorecard status:
- Scorecard in progress: hourglass icon
- Scorecard finished: check icon
- Scorecard in review (submitted, but not approved yet): check icon
- Scorecard completed (submitted and approved from server-side): lock icon