### PR TITLE
fix video player and send email are not working on android 11

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,13 @@
     <queries>
         <package android:name="org.instedd.ilabsea.community_scorecard.store" />
         <package android:name="org.instedd.ilabsea.community_scorecard.services" />
+        <intent>
+            <action android:name="com.google.android.youtube.api.service.START" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND"/>
+            <data android:mimeType="*/*" />
+        </intent>
     </queries>
 
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
This pull request is fixing the issues caused on the Android 11 devices:
- Unable to play the instruction video of the proposed indicator method even the device already has a Youtube app installed
- Unable to open the mail app to send an email when clicking on the email card item on the contact screen.

**Note**: 
- Tested on Android 11, 10, 8
- This issue happened because Android does not allow connections to other apps (like YouTube) by default since Android 11.

*Reference links:
- https://github.com/davidohayon669/react-native-youtube/issues/518#issuecomment-877669784  (fix the play video issue)
- https://stackoverflow.com/a/66601650/2950224 (fixing the send email issue)