### PR TITLE
Sort the facilitator by order when query all the data of the facilitator

### DIFF
--- a/app/models/Facilitator.js
+++ b/app/models/Facilitator.js
@@ -10,7 +10,7 @@ const Facilitator = (() => {
   }
 
   function getAll(scorecardUuid) {
-    return realm.objects('Facilitator').filtered(`scorecard_uuid='${scorecardUuid}'`);
+    return realm.objects('Facilitator').filtered(`scorecard_uuid='${scorecardUuid}' SORT(order ASC)`);
   }
 
   function create(data) {


### PR DESCRIPTION
This pull request is adding the sort by order to the facilitator query when querying for all saved facilitators by the scorecard.