### PR TITLE
Disable save button when selected endpoint is not changed in endpoint picker

### DIFF
--- a/app/components/BottomSheetPicker/BottomSheetPickerContent.js
+++ b/app/components/BottomSheetPicker/BottomSheetPickerContent.js
@@ -18,9 +18,10 @@ class BottomSheetPickerContent extends React.Component {
     super(props);
     this.state = {
       selectedItem: this.props.selectedItem,
-      searchedFacilitator: '',
+      searchedItem: '',
       items: this.props.items,
       contentHeight: this.props.contentHeight,
+      isButtonDisabled: true,
     };
   }
 
@@ -32,7 +33,11 @@ class BottomSheetPickerContent extends React.Component {
     if (item.disabled)
       return;
 
-    this.setState({ selectedItem: item.value });
+    this.setState({
+      selectedItem: item.value,
+      isButtonDisabled: !!this.props.isSelctedItemMatched ? this.props.isSelctedItemMatched(item.value) : false
+    });
+
     this.props.onSelectItem(item)
   }
 
@@ -57,14 +62,14 @@ class BottomSheetPickerContent extends React.Component {
   searchFacilitator(text) {
     const filteredFacilitator = !!text ? this.props.items.filter(item => item.label.toLowerCase().includes(text.toLowerCase())) : this.props.items;
     this.setState({
-      searchedFacilitator: text,
+      searchedItem: text,
       items: filteredFacilitator
     });
   }
 
   renderSearchBox() {
     return <SearchBox
-              value={this.state.searchedFacilitator}
+              value={this.state.searchedItem}
               onChangeText={(text) => this.searchFacilitator(text)}
               onFocus={(status) => this.props.onSearchBoxFocus()}
               onClearSearch={() => this.searchFacilitator('')}
@@ -73,7 +78,7 @@ class BottomSheetPickerContent extends React.Component {
 
   renderBottomSection() {
     return <BottomSheetPickerContentBottomSection bottomInfoMessage={this.props.bottomInfoMessage}
-            onPressButton={() => this.props.onPressBottomButton()} />
+            onPressButton={() => this.props.onPressBottomButton()} isButtonDisabled={this.state.isButtonDisabled} />
   }
 
   render() {

--- a/app/components/BottomSheetPicker/BottomSheetPickerContentBottomSection.js
+++ b/app/components/BottomSheetPicker/BottomSheetPickerContentBottomSection.js
@@ -11,7 +11,9 @@ class BottomSheetPickerContentBottomSection extends React.Component {
     return <View style={{paddingTop: 10}}>
               { !!this.props.bottomInfoMessage && this.props.bottomInfoMessage }
 
-              <FormBottomSheetButton isValid={true} save={() => this.props.onPressButton()}
+              <FormBottomSheetButton
+                isValid={!this.props.isButtonDisabled}
+                save={() => this.props.onPressButton()}
                 wrapperStyle={{paddingTop: 0, marginTop: 10}}
                 label={this.context.translations.change}
               />

--- a/app/components/Setting/SettingUrlEndpointPicker.js
+++ b/app/components/Setting/SettingUrlEndpointPicker.js
@@ -67,6 +67,7 @@ class SettingUrlEndpointPicker extends React.Component {
             hasAddButton={true}
             hasBottomButton={true}
             bottomInfoMessage={<EndpointUrlWarningMessages/>}
+            isSelctedItemMatched={(selectedEndpoint) => selectedEndpoint === this.props.backendUrl}
           />
   }
 

--- a/app/services/endpoint_migration_service.js
+++ b/app/services/endpoint_migration_service.js
@@ -12,9 +12,11 @@ const endpointMigrationService = (() => {
   async function handleEndpointMigration() {
     let endpointUrls = JSON.parse(await AsyncStorage.getItem('ENDPOINT_URLS')) || defaultEndpointUrls;
     const defaultEndpoint = JSON.parse(await AsyncStorage.getItem('SETTING')).backendUrl;
-    endpointUrls = endpointUrls.filter(endpointUrl => endpointUrl.type != DEFAULT && endpointUrl.value != defaultEndpoint)
 
-    if (defaultEndpoint && !EndpointUrl.isExist('', defaultEndpoint))
+    if (!!defaultEndpoint)
+      endpointUrls = endpointUrls.filter(endpointUrl => endpointUrl.type != DEFAULT && endpointUrl.value != defaultEndpoint)
+
+    if (!!defaultEndpoint && !EndpointUrl.isExist('', defaultEndpoint))
       endpointUrls.push({ label: 'Local Development Server', value: defaultEndpoint, type: CUSTOM });
 
     endpointUrls.map(endpointUrl => {


### PR DESCRIPTION
This is request is to make some enhancements:
- Disable "Save" button when the focused item in the endpoint list item has the same value as the selected endpoint URL
- Fix the issue in endpoint migration of saving empty endpoint URLs to realm when the app doesn't have a custom endpoint URL