### PR TITLE
fix unexpected popup alert message in new scorecard screen

### DIFF
--- a/app/components/ScorecardResult/ScorecardResultTableRow.js
+++ b/app/components/ScorecardResult/ScorecardResultTableRow.js
@@ -93,7 +93,7 @@ export default class ScorecardResultTableRow extends Component {
 
     return (
       <TableWrapper style={styles.row} borderStyle={{borderColor: Color.listItemBorderColor, borderWidth: 1}}>
-        { this._renderTextCell(languageIndicator.content || indiclanguageIndicatorator.name, 4) }
+        { this._renderTextCell(languageIndicator.content, 4) }
         { this._renderMedian() }
         { editableFields.map((fieldName, index) => (
           <Cell key={index} data={this.renderCell(fieldName, languageIndicator)} textStyle={styles.text} style={{flex: 3}}/>

--- a/app/constants/url_constant.js
+++ b/app/constants/url_constant.js
@@ -7,6 +7,8 @@ export const validScorecardUrls = [
   'http://isaf-stg.ilabsea.org/scorecards',
   'https://isaf-stg.digital-csc.org',
   'http://isaf-stg.digital-csc.org',
+  'https://isaf.digital-csc.org',
+  'http://isaf.digital-csc.org',
 ];
 
 export const defaultEndpointUrls = [

--- a/app/utils/scorecard_util.js
+++ b/app/utils/scorecard_util.js
@@ -1,6 +1,7 @@
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { getDeviceStyle, isShortWidthScreen } from './responsive_util';
+import urlUtil from './url_util';
 import { isNumber } from './string_util';
 import { validScorecardUrls } from '../constants/url_constant';
 import { ERROR_INVALID_SCORECARD_URL } from '../constants/error_constant';
@@ -50,7 +51,9 @@ export const handleScorecardCodeClipboard = async (updateErrorState) => {
   let copiedText = await Clipboard.getString();
   copiedText = copiedText.replace(' ', '');
 
-  if (copiedText == 'null' || copiedText == '')
+  // Not showing alert message when copied text is null or '' or is not URL format and not number only
+  // To prevent the alert message keep showing when the user copies the text for other purpose then open CSC mobile
+  if (_isNotValidCopiedText(copiedText))
     return;
 
   if (!_isValidScorecardUrl(copiedText) && !isNumber(copiedText)) {
@@ -81,6 +84,10 @@ const _isValidScorecardUrl = (copiedText) => {
   }
 
   return false;
+}
+
+const _isNotValidCopiedText = (copiedText) => {
+  return copiedText == '' || (!urlUtil.isUrl(copiedText) && !isNumber(copiedText));
 }
 
 export const isScorecardInReview = (scorecard) => {

--- a/app/utils/url_util.js
+++ b/app/utils/url_util.js
@@ -1,6 +1,7 @@
 const urlUtil = (() => {
   return {
     isUrlValid,
+    isUrl
   }
 
   function isUrlValid(url) {
@@ -9,6 +10,12 @@ const urlUtil = (() => {
     return regexp.test(url);
   }
 
+  function isUrl(string) {
+    const matchpattern = new RegExp(`^https?://(?:www\.)?${domainNameValidationPattern()}`);
+    return matchpattern.test(string)
+  }
+
+  // private method
   function ipAddressValidationPattern() {
     const octetsPattern = '[0-9]{1,3}';
     const portPattern = '[0-9]{1,5}';


### PR DESCRIPTION
This pull request is fixing the unexpected popup alert message on the new scorecard screen.

**Cause of the unexpected alert**
     The user copies the text to paste it to the other place (the copied text will not be clear after the user pastes it) then the user returns or opens the CSC mobile app, in the new scorecard screen, it will detect whether there is a text being copied. If the copied text is invalid, it will show an alert message.

**Current solution**
     If the copied text is not a valid URL and is not a number-only string, it will not show the alert message.

