### PR TITLE
Fix error saving null or unexpected value in endpoint url async storage

### DIFF
--- a/app/components/BottomSheetPicker/BottomSheetPicker.js
+++ b/app/components/BottomSheetPicker/BottomSheetPicker.js
@@ -23,7 +23,8 @@ class BottomSheetPicker extends React.Component {
   }
 
   getLabel() {
-    if (!this.props.items) return '';
+    if (!this.props.items)
+      return this.props.label || '';
 
     const selectedItem = this.props.items.filter(item => item.value === this.props.selectedItem);
     return selectedItem.length > 0 ? selectedItem[0].label : this.props.label;

--- a/app/components/BottomSheetPicker/BottomSheetPicker.js
+++ b/app/components/BottomSheetPicker/BottomSheetPicker.js
@@ -18,26 +18,14 @@ class BottomSheetPicker extends React.Component {
   static contextType = LocalizationContext;
   constructor(props) {
     super(props);
-    this.state = {
-      listItems: props.items || [],
-      label: props.label
-    }
-
     this.formRef = React.createRef();
     this.formModalRef = React.createRef();
   }
 
-  componentDidUpdate() {
-    if (!!this.props.items && this.props.items != this.state.listItems) {
-      this.setState({
-        listItems: this.props.items,
-        label: this.getLabel()
-      });
-    }
-  }
-
   getLabel() {
-    const selectedItem = this.state.listItems.filter(item => item.value === this.props.selectedItem);
+    if (!this.props.items) return '';
+
+    const selectedItem = this.props.items.filter(item => item.value === this.props.selectedItem);
     return selectedItem.length > 0 ? selectedItem[0].label : this.props.label;
   }
 

--- a/app/components/BottomSheetPicker/BottomSheetPickerContent.js
+++ b/app/components/BottomSheetPicker/BottomSheetPickerContent.js
@@ -48,7 +48,7 @@ class BottomSheetPickerContent extends React.Component {
               onSelectItem={(item) => this.onSelectItem(item)}
               showSubtitle={this.props.showSubtitle}
               showEditForm={this.props.showEditForm}
-              isAllowToEdit={(editItem, selectedItem) => this.props.isAllowToEdit(editItem, selectedItem)}
+              isAllowToEdit={this.props.isAllowToEdit}
               defaultSelectedItem={this.props.selectedItem}
            />
   }

--- a/app/components/ErrorMessageModal/ErrorMessageModal.js
+++ b/app/components/ErrorMessageModal/ErrorMessageModal.js
@@ -31,7 +31,8 @@ class ErrorMessageModal extends Component {
     this.setState({
       backendUrl: (setting != null && !!JSON.parse(setting).backendUrl) ? JSON.parse(setting).backendUrl : environment.defaultEndpoint,
     }, () => {
-      AsyncStorage.setItem('ENDPOINT_URL', this.state.backendUrl);
+      if (!!this.state.backendUrl)
+        AsyncStorage.setItem('ENDPOINT_URL', this.state.backendUrl);
     });
   }
 

--- a/app/components/Setting/SettingForm.js
+++ b/app/components/Setting/SettingForm.js
@@ -47,6 +47,7 @@ class SettingForm extends Component {
         updateBackendUrl={(backendUrl) => this.setState({ backendUrl })}
         formRef={this.props.formRef}
         formModalRef={this.props.formModalRef}
+        savedEndpoint={this.props.backendUrl}
       />
     )
   }

--- a/app/components/Setting/SettingUrlEndpointForm.js
+++ b/app/components/Setting/SettingUrlEndpointForm.js
@@ -20,6 +20,7 @@ class SettingUrlEndpointForm extends React.Component {
   static contextType = LocalizationContext
   constructor(props) {
     super(props);
+
     this.state = {
       endpointLabel: props.editEndpoint ? props.editEndpoint.label : '',
       endpointValue: props.editEndpoint ? props.editEndpoint.value : 'https://',
@@ -28,7 +29,7 @@ class SettingUrlEndpointForm extends React.Component {
       endpointValueErrorMsg: '',
       isFormValid: props.editEndpoint ? true : false,
       isEndpointValueFocused: false,
-      isAllowToDeleteOrEdit: props.editEndpoint ? endpointFormService.isAllowToDeleteOrEdit(props.editEndpoint, props.selectedEndpoint) : true
+      isAllowToDeleteOrEdit: props.editEndpoint ? endpointFormService.isAllowToDeleteOrEdit(props.editEndpoint, props.selectedEndpoint, props.savedEndpoint) : true
     }
     this.scrollViewRef = React.createRef();
   }

--- a/app/components/Setting/SettingUrlEndpointPicker.js
+++ b/app/components/Setting/SettingUrlEndpointPicker.js
@@ -68,7 +68,7 @@ class SettingUrlEndpointPicker extends React.Component {
             hasBottomButton={true}
             bottomInfoMessage={<EndpointUrlWarningMessages/>}
             isSelctedItemMatched={(selectedEndpoint) => selectedEndpoint === this.props.backendUrl}
-            isAllowToEdit={(editItem, selectedItem) => endpointFormService.isAllowToDeleteOrEdit(editItem, selectedItem)}
+            isAllowToEdit={(editItem, selectedItem) => endpointFormService.isAllowToDeleteOrEdit(editItem, selectedItem, this.props.savedEndpoint)}
           />
   }
 
@@ -90,6 +90,7 @@ class SettingUrlEndpointPicker extends React.Component {
               editEndpoint={editEndpoint}
               selectedEndpoint={this.state.selectedEndpoint}
               reloadEndpoint={() => this.reloadEndpoint()}
+              savedEndpoint={this.props.savedEndpoint}
            />
   }
 
@@ -102,6 +103,7 @@ class SettingUrlEndpointPicker extends React.Component {
 
   render() {
     const {translations} = this.context;
+
     return (
       <View style={{marginBottom: 30, marginTop: 5}}>
         <BottomSheetPicker

--- a/app/components/Setting/SettingUrlEndpointPicker.js
+++ b/app/components/Setting/SettingUrlEndpointPicker.js
@@ -103,7 +103,6 @@ class SettingUrlEndpointPicker extends React.Component {
 
   render() {
     const {translations} = this.context;
-
     return (
       <View style={{marginBottom: 30, marginTop: 5}}>
         <BottomSheetPicker

--- a/app/services/authentication_service.js
+++ b/app/services/authentication_service.js
@@ -22,15 +22,19 @@ const authenticationService = (() => {
     const response = await SessionApi.authenticate(email, password);
 
     handleApiResponse(response, (responseData) => {
-      resetLockService.resetLockData(FAILED_SIGN_IN_ATTEMPT);
-      AsyncStorage.setItem('IS_CONNECTED', 'true');
-      AsyncStorage.setItem('AUTH_TOKEN', responseData.authentication_token);
-      AsyncStorage.setItem('TOKEN_EXPIRED_DATE', responseData.token_expired_date);
-      MobileTokenService.updateToken(responseData.program_id);
+      if (!!responseData.authentication_token) {
+        resetLockService.resetLockData(FAILED_SIGN_IN_ATTEMPT);
+        AsyncStorage.setItem('IS_CONNECTED', 'true');
+        AsyncStorage.setItem('AUTH_TOKEN', responseData.authentication_token);
+        AsyncStorage.setItem('TOKEN_EXPIRED_DATE', responseData.token_expired_date);
+        MobileTokenService.updateToken(responseData.program_id);
 
-      authenticationFormService.clearErrorAuthentication();
-      contactService.downloadContacts(null, null);
-      successCallback(responseData);
+        authenticationFormService.clearErrorAuthentication();
+        contactService.downloadContacts(null, null);
+        successCallback(responseData);
+      }
+      else
+        errorCallback('theServerUrlIsInvalid', false, false)
     }, (error) => {
       let isInvalidAccount = false;
 

--- a/app/services/authentication_service.js
+++ b/app/services/authentication_service.js
@@ -65,7 +65,7 @@ const authenticationService = (() => {
   async function saveSignInInfo(state) {
     const { backendUrl, email, password } = state;
 
-    AsyncStorage.setItem('ENDPOINT_URL', backendUrl);
+    if (!!backendUrl) AsyncStorage.setItem('ENDPOINT_URL', backendUrl);
     AsyncStorage.setItem('SETTING', JSON.stringify({
       backendUrl: backendUrl,
       email: email,

--- a/app/services/endpoint_form_service.js
+++ b/app/services/endpoint_form_service.js
@@ -66,9 +66,9 @@ const endpointFormService = (() => {
     return await AsyncStorage.getItem('TEMP_ENDPOINT_URL');
   }
 
-  function isAllowToDeleteOrEdit(editEndpoint, selectedEndpoint) {
+  function isAllowToDeleteOrEdit(editEndpoint, selectedEndpoint, savedEndpoint) {
     if (!Scorecard.allScorecardContainEndpoint(editEndpoint.value))
-      return !!editEndpoint && editEndpoint.value != selectedEndpoint;
+      return !!editEndpoint && editEndpoint.value != selectedEndpoint && editEndpoint.value != savedEndpoint;
     
     return false;
   }


### PR DESCRIPTION
This pull request is fixing the issues:
- Saving null or undefined endpoint URL to async storage
- Error when deleting the endpoint URL
- Prevent the user from deleting or editing the endpoint URL that is currently authenticated (in the previous version, the user is able to delete or edit the currently authenticated endpoint URL by selecting and saving a different endpoint URL in the endpoint bottom sheet)
- Prevent the error when the user uses an invalid endpoint URL to run authentication and it returns as success without authentication_token