### PR TITLE
Allow bottom sheet title to render in 2 lines and hide view more labe…

### DIFF
--- a/app/components/BottomSheetModalTitle.js
+++ b/app/components/BottomSheetModalTitle.js
@@ -1,10 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { Text, View } from 'react-native';
 import DashedLine from './DashedLine';
 
 import {LocalizationContext} from './Translations';
 import OutlinedButton from './OutlinedButton';
 import styles from '../themes/modalStyle';
+import { smallTitleFontSize, titleFontSize } from '../utils/font_size_util';
 import { getDeviceStyle, containerPadding } from '../utils/responsive_util';
 import PopupModalTabletStyles from '../styles/tablet/PopupModalComponentStyle';
 import PopupModalMobileStyles from '../styles/mobile/PopupModalComponentStyle';
@@ -13,6 +14,7 @@ const responsiveStyles = getDeviceStyle(PopupModalTabletStyles, PopupModalMobile
 
 const BottomSheetModalTitle = (props) => {
   const { translations } = useContext(LocalizationContext);
+  const [ isMultiLine, setIsMultiLine ] = useState(false);
 
   function renderRightButton() {
     return <View style={{paddingBottom: containerPadding, paddingTop: containerPadding - getDeviceStyle(6, 10)}}>
@@ -24,12 +26,18 @@ const BottomSheetModalTitle = (props) => {
           </View>
   }
 
+  function headerFontSize() {
+    return { fontSize: isMultiLine ? smallTitleFontSize() : titleFontSize() };
+  }
+
   return (
     <View>
       <View style={{flexDirection: 'row', justifyContent: 'space-between', paddingHorizontal: containerPadding}}>
-        <Text style={[styles.title, responsiveStyles.headerTitle]} numberOfLines={1}>
+        <Text style={[styles.title, responsiveStyles.headerTitle, headerFontSize()]} numberOfLines={2}
+          onTextLayout={(e) => { if (!isMultiLine) setIsMultiLine(e.nativeEvent.lines.length > 1) }}
+        >
           { props.title }
-          { props.isRequire && <Text style={[{color: Color.redColor}, responsiveStyles.headerTitle]}> *</Text> }
+          { props.isRequire && <Text style={[{color: Color.redColor}, responsiveStyles.headerTitle, headerFontSize()]}> *</Text> }
         </Text>
 
         { !!props.hasAddButton && renderRightButton() }

--- a/app/components/Tip.js
+++ b/app/components/Tip.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
-
 import { View, Text, StyleSheet, Image } from 'react-native';
+import DeviceInfo from 'react-native-device-info'
 
 import { LocalizationContext } from '../components/Translations';
 import { Icon } from 'native-base';
@@ -46,7 +46,9 @@ export default class Tip extends Component {
                 { translations.tips } - { translations[getTipByScreenName(this.props.screenName).mainTitle] }
               </Text>
 
-              <Text style={[{color: Color.headerColor}, responsiveStyles.viewDetailLabel]}>{translations.viewTips}</Text>
+              { DeviceInfo.isTablet() &&
+                <Text style={[{color: Color.headerColor}, responsiveStyles.viewDetailLabel]}>{translations.viewTips}</Text>
+              }
               <Icon name='chevron-forward-outline' style={[{color: Color.headerColor}, responsiveStyles.viewDetailIcon]} />
             </View>
           </View>

--- a/app/components/Tip/TipModal.js
+++ b/app/components/Tip/TipModal.js
@@ -64,7 +64,7 @@ export default class TipModal extends Component {
             dashedLineStyle={{ marginBottom: 8 }}
           />
 
-          <View style={{padding: containerPadding, paddingBottom: 0}}>
+          <View style={{paddingHorizontal: containerPadding}}>
             <Text style={[styles.title, responsiveStyles.headerTitle, { marginBottom: 10, fontSize: bodyFontSize() }]}>{ this.state.tip.title }</Text>
 
             { this.renderTips() }

--- a/app/constants/modal_constant.js
+++ b/app/constants/modal_constant.js
@@ -7,9 +7,9 @@ export const SCORECARD_RESULT = 'SCORECARD_RESULT';
 
 export const tipModalSnapPoints = {
   'PROPOSED_INDICATOR': ['54%', getDeviceStyle('78%', isShortScreenDevice() ? '81%' : '76%')],
-  'INDICATOR_DEVELOPMENT': [getDeviceStyle('35.5%', '43%')],
-  'VOTING_INDICATOR': [getDeviceStyle('36%', isShortScreenDevice() ? '43%' : '40%')],
-  'SCORECARD_RESULT': [getDeviceStyle('36%', isShortScreenDevice() ? '42%' : '47%')],
+  'INDICATOR_DEVELOPMENT': [getDeviceStyle('37%', '43%')],
+  'VOTING_INDICATOR': [getDeviceStyle('37%', isShortScreenDevice() ? '43%' : '41%')],
+  'SCORECARD_RESULT': [getDeviceStyle('37%', isShortScreenDevice() ? '42%' : '47%')],
 };
 
 export const participantModalSnapPoints = getDeviceStyle(['70%'], isShortScreenDevice() ? ['85%'] : ['75%']);

--- a/app/styles/mobile/PopupModalComponentStyle.js
+++ b/app/styles/mobile/PopupModalComponentStyle.js
@@ -6,7 +6,9 @@ const PopupModalComponentStyles = StyleSheet.create({
   headerTitle: {
     fontSize: titleFontSize(),
     marginBottom: 0,
-    paddingVertical: containerPadding
+    paddingVertical: containerPadding,
+    flex: 1,
+    paddingRight: 5,
   },
   label: {
     fontSize: bodyFontSize()

--- a/app/styles/tablet/PopupModalComponentStyle.js
+++ b/app/styles/tablet/PopupModalComponentStyle.js
@@ -6,7 +6,9 @@ const PopupModalComponentStyles = StyleSheet.create({
   headerTitle: {
     fontSize: titleFontSize(),
     marginBottom: 0,
-    paddingVertical: containerPadding
+    paddingVertical: containerPadding,
+    flex: 1,
+    paddingRight: 5
   },
   label: {
     fontSize: bodyFontSize(),

--- a/app/utils/font_size_util.js
+++ b/app/utils/font_size_util.js
@@ -20,6 +20,11 @@ export const titleFontSize = () => {
   return getDeviceStyle(20, mobileFontSize);
 }
 
+export const smallTitleFontSize = () => {
+  const mobileFontSize = getMobileFontSizeByPixelRatio(16, 14);
+  return getDeviceStyle(17, mobileFontSize);
+}
+
 export const bigNavigationHeaderTitleFontSize = () => {
   const mobileFontSize = getMobileFontSizeByPixelRatio(26, 24);
   return getDeviceStyle(28, mobileFontSize);


### PR DESCRIPTION
This pull request is enhancing the UI and style of:
- Allow the bottom sheet title to render in 2 lines (when the title is rendered in 2 lines the font size will be smaller than the font size of the 1 line title)
- Hide the "មើលបន្ថែម" label of the Tip card when opening the app on a mobile device

Below are the screenshots of the bottom sheet with 1 line and 2 lines of title, and the tip card on mobile and tablet.
[bottom sheet with 2 lines title.zip](https://github.com/ilabsea/scorecard_mobile/files/8678949/bottom.sheet.with.2.lines.title.zip)


