### PR TITLE
hot-fix custom indicator name is not showing in indicator development…

### DIFF
--- a/app/helpers/indicator_helper.js
+++ b/app/helpers/indicator_helper.js
@@ -24,7 +24,6 @@ const indicatorHelper = (() => {
   function getDisplayIndicator(proposedIndicator, scorecardObj) {
     const scorecard = scorecardObj || Scorecard.find(proposedIndicator.scorecard_uuid);
     const indicator = Indicator.find(proposedIndicator.indicatorable_id, proposedIndicator.indicatorable_type);
-
     let langIndicator = LanguageIndicator.findByIndicatorAndLanguageCode(proposedIndicator.indicatorable_id, scorecard.audio_language_code);
     langIndicator = langIndicator || indicator;
     langIndicator = JSON.parse(JSON.stringify(langIndicator));
@@ -32,7 +31,7 @@ const indicatorHelper = (() => {
 
     if (!scorecard.isSameLanguageCode) {
       let textIndi = LanguageIndicator.findByIndicatorAndLanguageCode(proposedIndicator.indicatorable_id, scorecard.text_language_code);
-      langIndicator.content = !!textIndi && textIndi.content;
+      langIndicator.content = !!textIndi ? textIndi.content : langIndicator.content;
     }
 
     return langIndicator;

--- a/app/services/custom_indicator_service.js
+++ b/app/services/custom_indicator_service.js
@@ -26,18 +26,14 @@ const customIndicatorService = (() => {
     };
 
     const scorecard = Scorecard.find(scorecardUuid);
-    const customLanguageIndicator = {
-      id: uuidv4(),
-      content: indicator.name,
-      language_code: scorecard.audio_language_code,
-      local_audio: indicator.local_audio,
-      scorecard_uuid: scorecardUuid,
-      indicator_id: customIndicator.uuid,
-      type: CUSTOM,
-    };
-
     Indicator.create(customIndicator);
-    LanguageIndicator.create(customLanguageIndicator);
+
+    LanguageIndicator.create(_getLanguageCustomIndicatorParams(indicator, scorecard, 'audio', customIndicator));
+
+    // Create another language indicator if the locale of the audio and text are different
+    if (!scorecard.isSameLanguageCode)
+      LanguageIndicator.create(_getLanguageCustomIndicatorParams(indicator, scorecard, 'text', customIndicator));
+
     customIndicator['indicatorable_id'] = customIndicator.uuid;
 
     if (!!participantUuid)
@@ -76,6 +72,19 @@ const customIndicatorService = (() => {
       if (index === customIndicators.length -1)
         Indicator.destroy(customIndicators);
     });
+  }
+
+  // private method
+  function _getLanguageCustomIndicatorParams(indicator, scorecard, languageType, customIndicator) {
+    return {
+      id: uuidv4(),
+      content: indicator.name,
+      language_code: languageType == 'text' ? scorecard.text_language_code : scorecard.audio_language_code,
+      local_audio: indicator.local_audio,
+      scorecard_uuid: scorecard.uuid,
+      indicator_id: customIndicator.uuid,
+      type: CUSTOM,
+    };
   }
 })();
 


### PR DESCRIPTION
This pull request is fixing the issues:
- Custom indicator is not displaying the name in the indicator development, voting list, voting form, and scorecard result screens
- App gets crashed when it is on the scorecard result screen

**Cause of the error**
- The user selects different locales of the text and audio
- The language indicator of the custom indicator with the language_code of text locale is not created

**Solution**
- Create language indicator with the language code of the text locale if the text locale and audio locale are different