### PR TITLE
Fix getting incorrect endpoint url after redirect from play video screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -67,6 +67,8 @@ const App: () => React$Node = () => {
     SplashScreen.hide();
     MobileTokenService.handleSyncingToken();
 
+    // Clear the unsaved data of the setting when the app is freshly lauching,
+    // to prevent the setting screen from using the unsaved data after the user killed the app
     settingHelper.clearTempSettingData();
 
     AppState.addEventListener("change", (nextAppState) => {
@@ -82,10 +84,6 @@ const App: () => React$Node = () => {
     scorecardEndpointService.handleScorecardEndpointUrlMigration();
     reLoginService.initReLoginStatus();
     appStatusService.handleAppInstallingStatus();
-
-    return () => {
-      settingHelper.clearTempSettingData();
-    }
   }, []);
 
   return (

--- a/App.js
+++ b/App.js
@@ -67,6 +67,8 @@ const App: () => React$Node = () => {
     SplashScreen.hide();
     MobileTokenService.handleSyncingToken();
 
+    settingHelper.clearTempSettingData();
+
     AppState.addEventListener("change", (nextAppState) => {
       scorecardDeletionService.deleteExpiredScorecardCard();
     });
@@ -80,6 +82,10 @@ const App: () => React$Node = () => {
     scorecardEndpointService.handleScorecardEndpointUrlMigration();
     reLoginService.initReLoginStatus();
     appStatusService.handleAppInstallingStatus();
+
+    return () => {
+      settingHelper.clearTempSettingData();
+    }
   }, []);
 
   return (

--- a/app/components/Setting/SettingBodyContent.js
+++ b/app/components/Setting/SettingBodyContent.js
@@ -110,6 +110,7 @@ class SettingBodyContent extends React.Component {
 
       const tracingStep = await isProposeByIndicatorBase() ? INDICATOR_BASE_STEP : PARTICIPANT_BASE_STEP;
       scorecardTracingStepsService.trace(null, tracingStep, email);
+      settingHelper.clearTempSettingData();
       navigationRef.current?.goBack();
     }, async (errorMessage, isLocked, isInvalidAccount) => {
       this.setState({

--- a/app/components/Setting/SettingForm.js
+++ b/app/components/Setting/SettingForm.js
@@ -26,9 +26,7 @@ class SettingForm extends Component {
   }
 
   componentDidMount = async () => {
-    const tempSettingData = await settingHelper.getTempSettingData();
-    const settingData = !!tempSettingData ? tempSettingData : JSON.parse(await AsyncStorage.getItem('SETTING'));
-
+    const settingData = await settingHelper.getSettingData();
     if (settingData !== null && !!settingData.email) {
       this.setState({
         email: settingData.email,

--- a/app/components/Setting/SettingForm.js
+++ b/app/components/Setting/SettingForm.js
@@ -27,9 +27,6 @@ class SettingForm extends Component {
 
   componentDidMount = async () => {
     const tempSettingData = await settingHelper.getTempSettingData();
-
-    console.log('temp setting data = ', tempSettingData);
-
     const settingData = !!tempSettingData ? tempSettingData : JSON.parse(await AsyncStorage.getItem('SETTING'));
 
     if (settingData !== null && !!settingData.email) {

--- a/app/components/Setting/SettingForm.js
+++ b/app/components/Setting/SettingForm.js
@@ -7,6 +7,8 @@ import SettingSelectPickers from './SettingSelectPickers';
 import SettingUrlEndpointPicker from './SettingUrlEndpointPicker';
 import SettingFormInputs from './SettingFormInputs';
 
+import settingHelper from '../../helpers/setting_helper';
+
 class SettingForm extends Component {
   static contextType = LocalizationContext
   constructor(props) {
@@ -24,11 +26,16 @@ class SettingForm extends Component {
   }
 
   componentDidMount = async () => {
-    const value = JSON.parse(await AsyncStorage.getItem('SETTING'));
-    if (value !== null && !!value.email) {
+    const tempSettingData = await settingHelper.getTempSettingData();
+
+    console.log('temp setting data = ', tempSettingData);
+
+    const settingData = !!tempSettingData ? tempSettingData : JSON.parse(await AsyncStorage.getItem('SETTING'));
+
+    if (settingData !== null && !!settingData.email) {
       this.setState({
-        email: value.email,
-        password: value.password,
+        email: settingData.email,
+        password: settingData.password,
       }, () => this.props.updateValidationStatus());
     }
   }
@@ -48,6 +55,7 @@ class SettingForm extends Component {
         formRef={this.props.formRef}
         formModalRef={this.props.formModalRef}
         savedEndpoint={this.props.backendUrl}
+        saveTempSettingData={() => this.saveTempSettingData()}
       />
     )
   }
@@ -62,6 +70,13 @@ class SettingForm extends Component {
            />
   }
 
+  saveTempSettingData() {
+    setTimeout(() => {
+      const { backendUrl, email, password } = this.state;
+      settingHelper.saveTempSettingData(backendUrl, email, password);
+    }, 100);
+  }
+
   render() {
     return (
       <View>
@@ -71,6 +86,7 @@ class SettingForm extends Component {
           formModalRef={this.props.formModalRef}
           proposedIndicatorMethod={this.props.proposedIndicatorMethod}
           email={this.state.email}
+          saveTempSettingData={() => this.saveTempSettingData()}
         />
       </View>
     )

--- a/app/components/Setting/SettingProposedIndicatorMethodPicker.js
+++ b/app/components/Setting/SettingProposedIndicatorMethodPicker.js
@@ -18,6 +18,7 @@ class SettingProposedIndicatorMethodPicker extends React.Component {
     this.props.formRef.current?.setSnapPoints(settingModalSnapPoints);
     this.props.formRef.current?.setBodyContent(<ProposedIndicatorMethodDetails accordionStatuses={accordionStatuses} email={this.props.email} />);
     this.props.formModalRef.current?.present();
+    this.props.saveTempSettingData();
   }
 
   render() {

--- a/app/components/Setting/SettingSelectPickers.js
+++ b/app/components/Setting/SettingSelectPickers.js
@@ -24,6 +24,7 @@ class SettingSelectPickers extends React.Component {
           formModalRef={this.props.formModalRef}
           proposedIndicatorMethod={this.props.proposedIndicatorMethod}
           email={this.props.email}
+          saveTempSettingData={() => this.props.saveTempSettingData()}
         />
 
         <SettingLanguagePicker

--- a/app/components/Setting/SettingUrlEndpointPicker.js
+++ b/app/components/Setting/SettingUrlEndpointPicker.js
@@ -76,6 +76,7 @@ class SettingUrlEndpointPicker extends React.Component {
     this.props.updateBackendUrl(endpointValue);
     this.setState({ selectedEndpoint: endpointValue });
     this.reloadEndpoint();
+    this.props.saveTempSettingData();
   }
 
   reloadEndpoint() {
@@ -98,7 +99,7 @@ class SettingUrlEndpointPicker extends React.Component {
     this.setState({ selectedEndpoint: this.state.currentSelectedEndpoint });
     this.props.updateBackendUrl(this.state.currentSelectedEndpoint);
     this.props.formModalRef.current?.dismiss();
-    endpointFormService.setTemporarySelectedEndpoint(this.state.currentSelectedEndpoint);
+    this.props.saveTempSettingData();
   }
 
   render() {

--- a/app/helpers/setting_helper.js
+++ b/app/helpers/setting_helper.js
@@ -4,6 +4,8 @@ import { INDICATOR_BASE, PARTICIPANT_BASE } from '../constants/main_constant';
 import { INDICATOR_BASE_STEP, PARTICIPANT_BASE_STEP } from '../constants/scorecard_step_constant';
 import { environment } from '../config/environment';
 
+const keyName = 'TEMP_SETTING_DATA';
+
 const settingHelper = (() => {
   return {
     changeable,
@@ -14,6 +16,9 @@ const settingHelper = (() => {
     getEndpointPickerHeight,
     getEndpointUrlForScorecard,
     getSavedEndpointUrl,
+    saveTempSettingData,
+    getTempSettingData,
+    clearTempSettingData,
   };
 
   async function changeable(newEndpoint) {
@@ -77,6 +82,18 @@ const settingHelper = (() => {
   async function getSavedEndpointUrl() {
     const savedSetting = JSON.parse(await AsyncStorage.getItem('SETTING'));
     return (!!savedSetting && !!savedSetting.backendUrl) ? savedSetting.backendUrl : environment.defaultEndpoint;
+  }
+
+  function saveTempSettingData(endpoint, email, password) {
+    AsyncStorage.setItem(keyName, JSON.stringify({ endpoint, email, password }));
+  }
+
+  async function getTempSettingData() {
+    return JSON.parse(await AsyncStorage.getItem(keyName));
+  }
+
+  function clearTempSettingData() {
+    AsyncStorage.removeItem(keyName);
   }
 })();
 

--- a/app/helpers/setting_helper.js
+++ b/app/helpers/setting_helper.js
@@ -14,11 +14,12 @@ const settingHelper = (() => {
     checkDefaultProposedIndicatorMethod,
     getProposedIndicatorMethodTracingStep,
     getEndpointPickerHeight,
-    getEndpointUrlForScorecard,
+    getFullyEndpointUrl,
     getSavedEndpointUrl,
     saveTempSettingData,
     getTempSettingData,
     clearTempSettingData,
+    getSettingData,
   };
 
   async function changeable(newEndpoint) {
@@ -71,7 +72,7 @@ const settingHelper = (() => {
     return heights[type];
   }
 
-  async function getEndpointUrlForScorecard() {
+  async function getFullyEndpointUrl() {
     const savedSetting = JSON.parse(await AsyncStorage.getItem('SETTING'));
     if (!savedSetting || !savedSetting.email)
       return '';
@@ -94,6 +95,11 @@ const settingHelper = (() => {
 
   function clearTempSettingData() {
     AsyncStorage.removeItem(keyName);
+  }
+
+  async function getSettingData() {
+    const tempSettingData = await getTempSettingData();
+    return !!tempSettingData ? tempSettingData : JSON.parse(await AsyncStorage.getItem('SETTING'));
   }
 })();
 

--- a/app/models/Scorecard.js
+++ b/app/models/Scorecard.js
@@ -153,7 +153,7 @@ const Scorecard = (() => {
   }
 
   async function hasMatchedEndpointUrl(scorecardUuid) {
-    const endpointUrl = await settingHelper.getEndpointUrlForScorecard();
+    const endpointUrl = await settingHelper.getFullyEndpointUrl();
     if (!endpointUrl) return false;
 
     const scorecard = find(scorecardUuid);
@@ -195,7 +195,7 @@ const Scorecard = (() => {
       primary_school: response.primary_school != null ? JSON.stringify(response.primary_school) : null,
       planned_start_date: Moment(response.planned_start_date).format(apiDateFormat),
       planned_end_date: Moment(response.planned_end_date).format(apiDateFormat),
-      endpoint_url: await settingHelper.getEndpointUrlForScorecard(),
+      endpoint_url: await settingHelper.getFullyEndpointUrl(),
     })
   }
 

--- a/app/screens/Setting/Setting.js
+++ b/app/screens/Setting/Setting.js
@@ -8,8 +8,8 @@ import FormBottomSheetModal from '../../components/FormBottomSheetModal/FormBott
 
 import { getProposedIndicatorMethod } from '../../utils/proposed_indicator_util';
 import internetConnectionService from '../../services/internet_connection_service';
+import settingHelper from '../../helpers/setting_helper';
 import { INDICATOR_BASE } from '../../constants/main_constant';
-
 
 class Setting extends Component {
   static contextType = LocalizationContext;
@@ -58,13 +58,18 @@ class Setting extends Component {
     this.formRef.current?.setBodyContent(null)
   }
 
+  goBack() {
+    settingHelper.clearTempSettingData();
+    this.props.navigation.goBack();
+  }
+
   render() {
     const {translations} = this.context;
 
     return (
       <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
         <View style={{flex: 1}}>
-          <NavigationHeader title={translations.setting} onBackPress={() => this.props.navigation.goBack()} />
+          <NavigationHeader title={translations.setting} onBackPress={() => this.goBack()} />
 
           { this.renderBodyContent() }
 

--- a/app/screens/Setting/Setting.js
+++ b/app/screens/Setting/Setting.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import { View, TouchableWithoutFeedback, Keyboard } from 'react-native';
+import { View, TouchableWithoutFeedback, Keyboard, BackHandler } from 'react-native';
 
 import {LocalizationContext} from '../../components/Translations';
 import SettingBodyContent from '../../components/Setting/SettingBodyContent';
@@ -35,11 +35,18 @@ class Setting extends Component {
       if (!this.componentIsUnmount)
         this.setState({ hasInternetConnection: hasConnection });
     });
+
+    // Redirect back to home screen and clear unsaved data when the user uses the android back button
+    this.backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+      this.goBack();
+      return true;
+    });
   }
 
   componentWillUnmount() {
     this.componentIsUnmount = true;
     this.unsubscribeNetInfo && this.unsubscribeNetInfo();
+    this.backHandler.remove();
   }
 
   renderBodyContent() {

--- a/app/services/app_status_service.js
+++ b/app/services/app_status_service.js
@@ -8,7 +8,7 @@ const appStatusService = (() => {
 
   // Check if the app version 1.5.2 is freshly installed, do not show the alert message
   async function handleAppInstallingStatus() {
-    if (reLoginService.isAppVersionForUpdateScorecard() && !await settingHelper.getEndpointUrlForScorecard())
+    if (reLoginService.isAppVersionForUpdateScorecard() && !await settingHelper.getFullyEndpointUrl())
       reLoginService.setHasReLoggedIn();
   }
 })();

--- a/app/services/endpoint_form_service.js
+++ b/app/services/endpoint_form_service.js
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-community/async-storage';
 import validationService from './validation_service';
 import { ENDPOINT_VALUE_FIELDNAME } from '../constants/endpoint_constant';
 import { CUSTOM } from '../constants/main_constant';
@@ -13,7 +12,6 @@ const endpointFormService = (() => {
     isValidForm,
     saveEndpointUrls,
     getErrorMessage,
-    setTemporarySelectedEndpoint,
     getSelectedEndpoint,
     isAllowToDeleteOrEdit,
   }
@@ -56,14 +54,9 @@ const endpointFormService = (() => {
     return endpointErrorMessage[fieldName][messageType];
   }
 
-  function setTemporarySelectedEndpoint(endpointUrl) {
-    if (!!endpointUrl)
-      AsyncStorage.setItem('TEMP_ENDPOINT_URL', endpointUrl)
-  }
-
   async function getSelectedEndpoint() {
-    const tempSelectedEndpoint = await AsyncStorage.getItem('TEMP_ENDPOINT_URL');
-    return !tempSelectedEndpoint ? settingHelper.getSavedEndpointUrl() : tempSelectedEndpoint;
+    const tempSettingData = await settingHelper.getTempSettingData()
+    return !tempSettingData ? settingHelper.getSavedEndpointUrl() : tempSettingData.endpoint;
   }
 
   function isAllowToDeleteOrEdit(editEndpoint, selectedEndpoint, savedEndpoint) {

--- a/app/services/scorecard_endpoint_service.js
+++ b/app/services/scorecard_endpoint_service.js
@@ -9,7 +9,7 @@ const scorecardEndpointService = (() => {
   }
 
   async function handleScorecardEndpointUrlMigration() {
-    const endpointUrl = await settingHelper.getEndpointUrlForScorecard();
+    const endpointUrl = await settingHelper.getFullyEndpointUrl();
 
     if (!endpointUrl) return;
 
@@ -20,7 +20,7 @@ const scorecardEndpointService = (() => {
     if (!reLoginService.isAppVersionForUpdateScorecard())
       return;
 
-    const endpointUrl = await settingHelper.getEndpointUrlForScorecard();
+    const endpointUrl = await settingHelper.getFullyEndpointUrl();
     _updateScorecardEndpoint(endpointUrl);
     reLoginService.setHasReLoggedIn();
   }


### PR DESCRIPTION
This pull request is fixing the issues:

- Getting incorrect endpoint URL after redirected back from the play instruction video screen
- Getting the saved email and password after redirected back from the play instruction video screen
       + In this case, the user has already logged in and input a new email and password -> open the play instruction video screen -> redirect back to the setting screen (the email and password text inputs should display the new email and password, not the previous logged in email and password)