### PR TITLE
Add program UUID and endpoint id to indicator schema

### DIFF
--- a/app/constants/schema_constant.js
+++ b/app/constants/schema_constant.js
@@ -19,4 +19,5 @@ export const schemaNames = [
   'ProposedIndicator',
   'VotingIndicator',
   'ScorecardProposedIndicator',
+  'EndpointUrl',
 ];

--- a/app/db/migrations/v18/endpointUrl.js
+++ b/app/db/migrations/v18/endpointUrl.js
@@ -13,3 +13,7 @@ const EndpointUrlSchema = {
 };
 
 export default EndpointUrlSchema;
+
+// "uuid" will not be used in the future, but it cannot be remove because it is used as primary key
+// See reference on the link below on "Primary Keys" section
+// https://www.mongodb.com/docs/realm-legacy/docs/javascript/latest/index.html

--- a/app/db/migrations/v19/endpointUrl.js
+++ b/app/db/migrations/v19/endpointUrl.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const EndpointUrlSchema = {
+  name: 'EndpointUrl',
+  primaryKey: 'uuid',
+  properties: {
+    uuid: 'string',
+    label: 'string',
+    value: 'string',
+    type: 'string',
+    order: 'int',
+    id: 'int'
+  },
+};
+
+export default EndpointUrlSchema;

--- a/app/db/migrations/v19/indicator.js
+++ b/app/db/migrations/v19/indicator.js
@@ -13,7 +13,7 @@ const IndicatorSchema = {
     scorecard_uuid: 'string?',
     type: 'string',
     program_uuid: 'string?',
-    endpoint_id: 'string?'
+    endpoint_id: 'int?'
   },
 };
 

--- a/app/db/migrations/v19/indicator.js
+++ b/app/db/migrations/v19/indicator.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const IndicatorSchema = {
+  name: 'Indicator',
+  primaryKey: 'uuid',
+  properties: {
+    uuid: 'string',
+    indicator_uuid: 'string?',
+    id: 'int?',
+    name: 'string',
+    facility_id: 'int?',
+    tag: 'string?',
+    scorecard_uuid: 'string?',
+    type: 'string',
+    program_uuid: 'string?',
+    endpoint_id: 'string?'
+  },
+};
+
+export default IndicatorSchema;

--- a/app/db/migrations/v19/languageIndicator.js
+++ b/app/db/migrations/v19/languageIndicator.js
@@ -1,0 +1,20 @@
+const LanguageIndicator = {
+  name: 'LanguageIndicator',
+  primaryKey: 'id',
+  properties: {
+    id: 'string',               // store language indicator id for predefined language indicator and uuid for custom language indicator
+    content: 'string?',
+    audio: 'string?',
+    language_code: 'string',
+    scorecard_uuid: 'string',
+    indicator_uuid: 'string',
+    local_audio: 'string?',
+    type: 'string',
+  },
+};
+
+export default LanguageIndicator;
+
+// filename of local_audio field will have format:
+//   'indicator_' + langauge_indicator.id + '_' + language_indicator.language_code + ".mp3";
+//   Ex: indicator_1_km.mp3

--- a/app/db/migrations/v19/languageIndicator.js
+++ b/app/db/migrations/v19/languageIndicator.js
@@ -7,7 +7,7 @@ const LanguageIndicator = {
     audio: 'string?',
     language_code: 'string',
     scorecard_uuid: 'string',
-    indicator_uuid: 'string',
+    indicator_uuid: 'string?',
     local_audio: 'string?',
     type: 'string',
   },

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -18,6 +18,7 @@ import schemaV13 from './schemas/schemaV13';
 import schemaV14 from './schemas/schemaV14';
 import schemaV16 from './schemas/schemaV16';
 import schemaV17 from './schemas/schemaV17';
+import schemaV19 from './schemas/schemaV19';
 
 const schemas = [
   schemaV1,
@@ -36,6 +37,7 @@ const schemas = [
   schemaV14,
   schemaV16,
   schemaV17,
+  schemaV19,
 ];
 
 // the first schema to update to is the current schema version

--- a/app/db/schemas/schemaV19.js
+++ b/app/db/schemas/schemaV19.js
@@ -1,0 +1,38 @@
+import ProgramLanguage from '../migrations/v3/programLanguage';
+import Scorecard from '../migrations/v17/scorecard';
+import ProposedIndicator from '../migrations/v12/proposedIndicator';
+import Indicator from '../migrations/v19/indicator';
+import Rating from '../migrations/v14/rating';
+import VotingIndicator from '../migrations/v14/votingIndicator';
+import Facilitator from '../migrations/v16/facilitator';
+
+import schemaHelper from '../../helpers/schema_helper';
+import { schemaNames } from '../../constants/schema_constant';
+
+const changedSchemas = [
+  { label: schemaNames[0], data: Scorecard },
+  { label: schemaNames[2], data: Indicator },
+  { label: schemaNames[5], data: Facilitator },
+  { label: schemaNames[10], data: Rating },
+  { label: schemaNames[13], data: ProgramLanguage },
+  { label: schemaNames[17], data: ProposedIndicator },
+  { label: schemaNames[18], data: VotingIndicator }
+];
+
+const schemaV19 = {
+  schema: schemaHelper.getSchemas(changedSchemas),
+  schemaVersion: 19,
+  migration: (oldRealm, newRealm) => {
+    if (oldRealm.schemaVersion < 19) {
+      const oldObjects = oldRealm.objects('Indicator');
+      const newObjects = newRealm.objects('Indicator');
+
+      oldObjects.map((oldObject, index) => {
+        newObjects[index].program_uuid = !oldObject.program_uuid ? '' : oldObject.program_uuid;
+        newObjects[index].endpoint_url = !oldObject.endpoint_url ? '' : oldObject.endpoint_url;
+      });
+    }
+  }
+}
+
+export default schemaV19;

--- a/app/db/schemas/schemaV19.js
+++ b/app/db/schemas/schemaV19.js
@@ -2,6 +2,8 @@ import ProgramLanguage from '../migrations/v3/programLanguage';
 import Scorecard from '../migrations/v17/scorecard';
 import ProposedIndicator from '../migrations/v12/proposedIndicator';
 import Indicator from '../migrations/v19/indicator';
+import LanguageIndicator from '../migrations/v19/languageIndicator';
+import EndpointUrl from '../migrations/v19/endpointUrl';
 import Rating from '../migrations/v14/rating';
 import VotingIndicator from '../migrations/v14/votingIndicator';
 import Facilitator from '../migrations/v16/facilitator';
@@ -12,11 +14,13 @@ import { schemaNames } from '../../constants/schema_constant';
 const changedSchemas = [
   { label: schemaNames[0], data: Scorecard },
   { label: schemaNames[2], data: Indicator },
+  { label: schemaNames[4], data: LanguageIndicator },
   { label: schemaNames[5], data: Facilitator },
   { label: schemaNames[10], data: Rating },
   { label: schemaNames[13], data: ProgramLanguage },
   { label: schemaNames[17], data: ProposedIndicator },
-  { label: schemaNames[18], data: VotingIndicator }
+  { label: schemaNames[18], data: VotingIndicator },
+  { label: schemaNames[20], data: EndpointUrl }
 ];
 
 const schemaV19 = {
@@ -31,12 +35,21 @@ const schemaV19 = {
         newEndpointUrls[index].id = !oldEndpointUrl.id ? (index + 1) : oldEndpointUrl.id;
       });
 
+      const oldLangIndicators = oldRealm.objects('LanguageIndicator');
+      const newLangIndicators = newRealm.objects('LanguageIndicator');
+
+      // Find the indicator and add the indicator_uuid to languageIndicator
+      oldLangIndicators.map((oldLangIndicator, index) => {
+        const indicator = oldRealm.objects('Indicator').filtered(`id = ${ parseInt(oldLangIndicator.indicator_id) }`)[0];
+        newLangIndicators[index].indicator_uuid = indicator.indicator_uuid || '';
+      });
+
       const oldIndicators = oldRealm.objects('Indicator');
       const newIndicators = newRealm.objects('Indicator');
 
       oldIndicators.map((oldIndicator, index) => {
         newIndicators[index].program_uuid = !oldIndicator.program_uuid ? '' : oldIndicator.program_uuid;
-        newIndicators[index].endpoint_id = !oldIndicator.endpoint_id ? '' : oldIndicator.endpoint_id;
+        newIndicators[index].endpoint_id = !oldIndicator.endpoint_id ? null : oldIndicator.endpoint_id;
       });
     }
   }

--- a/app/db/schemas/schemaV19.js
+++ b/app/db/schemas/schemaV19.js
@@ -24,12 +24,19 @@ const schemaV19 = {
   schemaVersion: 19,
   migration: (oldRealm, newRealm) => {
     if (oldRealm.schemaVersion < 19) {
-      const oldObjects = oldRealm.objects('Indicator');
-      const newObjects = newRealm.objects('Indicator');
+      const oldEndpointUrls = oldRealm.objects('EndpointUrl');
+      const newEndpointUrls = newRealm.objects('EndpointUrl');
 
-      oldObjects.map((oldObject, index) => {
-        newObjects[index].program_uuid = !oldObject.program_uuid ? '' : oldObject.program_uuid;
-        newObjects[index].endpoint_url = !oldObject.endpoint_url ? '' : oldObject.endpoint_url;
+      oldEndpointUrls.map((oldEndpointUrl, index) => {
+        newEndpointUrls[index].id = !oldEndpointUrl.id ? (index + 1) : oldEndpointUrl.id;
+      });
+
+      const oldIndicators = oldRealm.objects('Indicator');
+      const newIndicators = newRealm.objects('Indicator');
+
+      oldIndicators.map((oldIndicator, index) => {
+        newIndicators[index].program_uuid = !oldIndicator.program_uuid ? '' : oldIndicator.program_uuid;
+        newIndicators[index].endpoint_id = !oldIndicator.endpoint_id ? '' : oldIndicator.endpoint_id;
       });
     }
   }


### PR DESCRIPTION
This pull request is updating the schemas:
- Adding "id" to endpointUrl schema
- Adding "program_uuid" and "endpoint_id" to indicator schema
- Changing the"indicator_id" to "indicator_uuid" in languageIndicator schema
- Writing migration to update the existing records of endpointUrl, indicator, and languageIndicator