### PR TITLE
Handle update indicator UUID of existing indicator from older version

### DIFF
--- a/App.js
+++ b/App.js
@@ -34,7 +34,8 @@ import { SELECTED_FILTERS } from './app/constants/main_constant';
 import settingHelper from './app/helpers/setting_helper';
 
 Sentry.init({
-  dsn: 'https://5f4fd35d83f1473291df0123fca8ec00@o357910.ingest.sentry.io/5424146',
+  // dsn: 'https://5f4fd35d83f1473291df0123fca8ec00@o357910.ingest.sentry.io/5424146',
+  dsn: 'https://d252675dfeb049a0adf1ef7a4abe1b86@o952154.ingest.sentry.io/5901440',
 });
 
 const store = configureStore();

--- a/App.js
+++ b/App.js
@@ -34,8 +34,7 @@ import { SELECTED_FILTERS } from './app/constants/main_constant';
 import settingHelper from './app/helpers/setting_helper';
 
 Sentry.init({
-  // dsn: 'https://5f4fd35d83f1473291df0123fca8ec00@o357910.ingest.sentry.io/5424146',
-  dsn: 'https://d252675dfeb049a0adf1ef7a4abe1b86@o952154.ingest.sentry.io/5901440',
+  dsn: 'https://5f4fd35d83f1473291df0123fca8ec00@o357910.ingest.sentry.io/5424146',
 });
 
 const store = configureStore();

--- a/app/components/CreateNewIndicator/CreateNewIndicatorMain.js
+++ b/app/components/CreateNewIndicator/CreateNewIndicatorMain.js
@@ -64,12 +64,16 @@ class CreateNewIndicatorMain extends Component {
     )
   }
 
+  isChooseParticipantVisible() {
+    return this.props.indicators.length > 0 &&!this.props.isLoading && !this.props.isSearching && !this.props.isEdit;
+  }
+
   render() {
     return (
       <View style={{flex: 1}}>
-        { this.state.hasParticipantSection && this.renderParticipant() }
+        { (this.state.hasParticipantSection && this.props.indicators.length > 0) && this.renderParticipant() }
 
-        { (!this.props.isLoading && !this.props.isSearching && !this.props.isEdit) &&
+        { this.isChooseParticipantVisible() &&
           <Text style={{fontSize: subTitleFontSize(), color: Color.lightBlackColor, marginTop: this.state.hasParticipantSection ? getDeviceStyle(15, 10) : 0}}>
             {this.context.translations.chooseProposedIndicator}
           </Text>

--- a/app/components/ProposedIndicator/IndicatorSelection.js
+++ b/app/components/ProposedIndicator/IndicatorSelection.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import { LayoutAnimation, UIManager } from 'react-native';
+import { LayoutAnimation, UIManager, View } from 'react-native';
 
 import {LocalizationContext} from '../Translations';
 import ProposedIndicatorScrollView from './ProposedIndicatorScrollView';
@@ -54,7 +54,11 @@ class IndicatorSelection extends Component {
           </ProposedIndicatorScrollView>
         }
 
-        { (!this.props.isLoading && this.props.indicators.length) === 0 && <NoIndicatorMessage /> }
+        { (!this.props.isLoading && this.props.indicators.length) === 0 && 
+          <View style={{height: '100%'}}>
+            <NoIndicatorMessage />
+          </View>
+        }
 
         { !this.props.isSearching && this.renderAddNewIndicatorButton() }
       </React.Fragment>

--- a/app/models/Indicator.js
+++ b/app/models/Indicator.js
@@ -20,6 +20,7 @@ const Indicator = (() => {
     destroy,
     arePredefinedIndicatorsHaveUuid,
     deleteAll,
+    getPredefeinedIndicatorsWithoutUuid,
   };
 
   function find(indicatorId, type) {
@@ -127,6 +128,10 @@ const Indicator = (() => {
     realm.write(() => {
       realm.delete(indicators);
     });
+  }
+
+  function getPredefeinedIndicatorsWithoutUuid(facilityId) {
+    return realm.objects(MODEL).filtered(`facility_id = ${facilityId} AND type = '${PREDEFINED}' AND indicator_uuid = null OR indicator_uuid = ''`);
   }
 
   //private method

--- a/app/services/api_service.js
+++ b/app/services/api_service.js
@@ -26,9 +26,9 @@ const checkConnection = (callback) => {
 
 const handleApiResponse = (response, successCallback, errorCallback) => {
   if (response.error != undefined)
-    errorCallback(response.error);
+    !!errorCallback && errorCallback(response.error);
   else
-    successCallback(response.data);
+    !!successCallback && successCallback(response.data);
 }
 
 const getErrorType = (errorStatus) => {

--- a/app/services/indicator_service.js
+++ b/app/services/indicator_service.js
@@ -20,7 +20,7 @@ class IndicatorService {
       indicatorHelper.savePredefinedIndicator(scorecardUuid, indicators, successCallback);
       saveLanguageIndicator(scorecardUuid, indicators, successCallback)
     }, (error) => {
-      errorCallback(error);
+      !!errorCallback && errorCallback(error);
     })
   }
 
@@ -46,7 +46,7 @@ class IndicatorService {
         // Check and update indicator_uuid of predefined indicators
         const predefinedIndicator = Indicator.find(indicator.id, PREDEFINED);
         if (!!predefinedIndicator && !predefinedIndicator.indicator_uuid)
-          Indicator.update(predefinedIndicator.uuid, { indicator_uuid: indicator.uuid });
+          Indicator.update(predefinedIndicator.uuid, { indicator_uuid: indicator.uuid }, scorecard.uuid);
       });
 
       successCallback();

--- a/app/services/language_indicator_service.js
+++ b/app/services/language_indicator_service.js
@@ -62,7 +62,7 @@ const saveLanguageIndicator = (scorecardUUID, indicators, successCallback) => {
     }
     savedCount += 1;
   });
-  successCallback(savedCount === indicators.length, languageIndicatorPhase);
+  !!successCallback && successCallback(savedCount === indicators.length, languageIndicatorPhase);
 }
 
 const getLanguageIndicator = (scorecardUuid, indicatorUuid, type) => {


### PR DESCRIPTION
This pull request is fixed and added some enhancement:
- Handle updating the existing indicators and language indicators from the previous app version (v 1.4.4) that don't have the indicator_uuid, endpoint_id (the update action will be triggered when the user re-login).
- Update the alignment of the "No indicator" message in the indicator list to style in the middle of the screen