### PR TITLE
update the scorecard endpoint_url when swipe down to refresh in score…

### DIFF
--- a/app/components/ScorecardProgress/ScorecardProgressButtons.js
+++ b/app/components/ScorecardProgress/ScorecardProgressButtons.js
@@ -25,7 +25,6 @@ class ScorecardProgressButtons extends Component {
     super(props);
     this.state = {
       visibleConfirmModal: false,
-      progressMessage: '',
       isRefreshable: false,
       isAllowToFinish: false,
     };
@@ -34,7 +33,6 @@ class ScorecardProgressButtons extends Component {
   async componentDidMount() {
     this.setState({
       isRefreshable: await Scorecard.isRefreshable(this.props.scorecard),
-      progressMessage: await scorecardProgressService.getProgressMessage(this.props.indicators, this.props.scorecard),
       isAllowToFinish: await scorecardProgressService.isAllowToFinish(this.props.scorecard)
     });
   }
@@ -78,7 +76,7 @@ class ScorecardProgressButtons extends Component {
     if (this.state.isRefreshable)
       message = `${translations.toBeRemovedOn}: ${ scorecardHelper.getTranslatedRemoveDate(this.props.scorecard.uploaded_date, appLanguage) }`;
     else
-      message = translations[this.state.progressMessage]
+      message = translations[this.props.progressMessage]
 
     return (
       <Text style={{ fontSize: fontSize, color: Color.redColor, textAlign: 'center', fontFamily: FontFamily.title, paddingTop: 5}}>

--- a/app/components/ScorecardProgress/ScorecardProgressScrollView.js
+++ b/app/components/ScorecardProgress/ScorecardProgressScrollView.js
@@ -15,12 +15,7 @@ const responsiveStyles = getDeviceStyle(ScorecardProgressTabletStyles, Scorecard
 class ScorecardProgressScrollView extends React.Component {
   state = {
     isLoading: false,
-    isRefreshable: false
   };
-
-  async componentDidMount() {
-    this.setState({ isRefreshable: await Scorecard.isRefreshable(this.props.scorecard) });
-  }
 
   syncScorecard() {
     scorecardSyncService.syncScorecard(this.props.scorecard.uuid, (scorecard) => {
@@ -39,7 +34,6 @@ class ScorecardProgressScrollView extends React.Component {
     return (
       <PullToRefreshScrollView
         containerStyle={responsiveStyles.container}
-        allowPullToRefresh={this.state.isRefreshable}
         syncData={() => this.syncScorecard()}
         isLoading={this.state.isLoading}
         updateLoadingState={(isLoading) => this.updateLoadingState(isLoading)}


### PR DESCRIPTION
This pull request is fixing an issue that the user is unable to submit the scorecard because the endpoint URL of the scorecard is different from the currently connected endpoint by updating the scorecard endpoint URL when the user swipes down to refresh the scorecard in the scorecard progress screen.