### PR TITLE
Prevent the error of accessing the deleted record in scorecard list

### DIFF
--- a/app/localization/en.json
+++ b/app/localization/en.json
@@ -167,8 +167,6 @@
   "status": "Status",
   "progressScorecards": "Progress scorecards",
   "completeScorecards": "Complete scorecards",
-  "deletedScorecard": "Deleted Scorecard",
-  "theScorecardDeleted": "The scorecard is deleted!",
   "step": "Step",
   "finishAndNext": "Finish and go next",
   "clickToPlayVoice": "Click to play voice",

--- a/app/localization/km.json
+++ b/app/localization/km.json
@@ -167,8 +167,6 @@
   "status": "ដំណាក់កាល",
   "progressScorecards": "ប័ណ្ណដាក់ពិន្ទុកំពុងដំណើរការ",
   "completeScorecards": "ប័ណ្ណដាក់ពិន្ទុដែលបានធ្វើចប់",
-  "deletedScorecard": "លុបប័ណ្ណដាក់ពិន្ទុ",
-  "theScorecardDeleted": "ប័ណ្ណដាក់ពិន្ទុនេះត្រូវបានលុប!",
   "step": "ជំហ៊ាន",
   "finishAndNext": "បញ្ចប់ ហើយទៅវគ្គបន្ទាប់",
   "clickToPlayVoice": "ចុចដើម្បីស្ដាប់សម្លេង",

--- a/app/screens/ScorecardList/ScorecardList.js
+++ b/app/screens/ScorecardList/ScorecardList.js
@@ -32,6 +32,7 @@ class ScorecardList extends Component {
       isLoading: true,
       visibleErrorModal: false,
       headerHeight: 0,
+      isDeleting: false
     }
   }
 
@@ -66,10 +67,9 @@ class ScorecardList extends Component {
   }
 
   onPress(scorecard) {
-    const { translations } = this.context
-
-    if (scorecard.isDeleted)
-      return Alert.alert(translations.deletedScorecard, translations.theScorecardDeleted);
+    // Prevent the user from viewing the scorecard detail if the scorecard is deleting
+    if (this.state.isDeleting)
+      return;
 
     this.props.setCurrentScorecard(scorecard);
     this.props.navigation.navigate('ScorecardProgress', {uuid: scorecard.uuid});
@@ -91,11 +91,14 @@ class ScorecardList extends Component {
     if (!this.state.selectedScorecard)
       return;
 
+    this.setState({ isDeleting: true })
+
     scorecardDeletionService.deleteScorecard(this.state.selectedScorecard.uuid, async () => {
       this.setState({
         visibleModal: false,
         scorecards: await scorecardFilterService.getFilteredScorecards(),
         selectedScorecard: null,
+        isDeleting: false,
       });
     }, (error) => {
       const isErrorUnauthorize =  error.status == '401' ? true : false;
@@ -109,7 +112,10 @@ class ScorecardList extends Component {
   }
 
   onMessageModalDismiss() {
-    this.setState({visibleModal: false});
+    this.setState({
+      visibleModal: false,
+      selectedScorecard: null,
+    });
     setTimeout(() => {
       this.setState({isConfirmModal: true});
     }, 500);


### PR DESCRIPTION
This pull request is preventing the user from accessing the deleted record after deleting the scorecard in the scorecard list screen.