### PR TITLE
Update the color of the check icon on the filter scorecard screen to …

### DIFF
--- a/app/components/FilterScorecard/FilterScorecardCheckIcon.js
+++ b/app/components/FilterScorecard/FilterScorecardCheckIcon.js
@@ -4,7 +4,7 @@ import Color from '../../themes/color';
 
 const FilterScorecardCheckIcon = () => {
   return (
-    <MaterialIcon name='check' size={24} color={Color.successColor} />
+    <MaterialIcon name='check' size={24} color={Color.clickableColor} />
   )
 }
 


### PR DESCRIPTION
This pull request is updating the color of the "check" icon on the filter scorecard screen to orange color to make it consistent with the check icon on the other screens.