### PR TITLE
Request permission to allow to open the dial app on android 11

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
             <action android:name="android.intent.action.SEND"/>
             <data android:mimeType="*/*" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.ACTION_DIAL" />
+        </intent>
     </queries>
 
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
This pull request is adding a request for permission to be able to open the dial app on android 11 or higher when the user clicks on the contact mobile number on the contact us screen.