### PR TITLE
Prevent the error of accessing the scorecard which has been invalidat…

### DIFF
--- a/app/components/ScorecardList/ScorecardListItem.js
+++ b/app/components/ScorecardList/ScorecardListItem.js
@@ -26,6 +26,7 @@ export default class ScorecardItem extends Component {
     this.state = {
       isDeletable: false,
     }
+    this.isResumable = true;
   }
 
   async componentDidMount() {
@@ -45,6 +46,11 @@ export default class ScorecardItem extends Component {
     )
   }
 
+  goToScorecardProgress() {
+    if (this.isResumable)
+      this.props.onPress();
+  }
+
   render() {
     let scorecard = this.props.scorecard || {};
 
@@ -53,8 +59,10 @@ export default class ScorecardItem extends Component {
         ref={ref => { this.itemRef = ref }}
         enabled={this.state.isDeletable}
         renderRightActions={this.renderDeleteAction}
+        onSwipeableOpen={() => this.isResumable = false }
+        onSwipeableClose={() => this.isResumable = true }
       >
-        <TouchableOpacity onPress={this.props.onPress} style={responsiveStyles.itemContainer} >
+        <TouchableOpacity onPress={() => this.goToScorecardProgress()} style={responsiveStyles.itemContainer} >
           <ScorecardListIcon scorecard={scorecard} />
           <ScorecardListInfo scorecard={scorecard} />
         </TouchableOpacity>


### PR DESCRIPTION
This pull request is fixing the error of accessing an object of type Scorecard which has been invalidated or deleted.

Cause of the error:
- This error might be caused when the user clicks on the delete button and scorecard card item at the same time, so the confirm delete modal will show on the scorecard progress screen. Then the user confirms to delete the scorecard and tries to continue the deleted scorecard.

Solution:
- Prevent the user from clicking the scorecard card item to redirect to the scorecard progress screen when the user swipe left on the scorecard card item to show the delete button.