### PR TITLE
Show the device id in the about screen

### DIFF
--- a/app/localization/en.json
+++ b/app/localization/en.json
@@ -385,5 +385,6 @@
   "unableToDownloadThePdfFile": "Unable to download the PDF file",
   "invalidUrl": "Invalid URL",
   "incorrectScorecardCode": "Incorrect scorecard code",
-  "theScorecardIsNotExist": "The scorecard is not exist"
+  "theScorecardIsNotExist": "The scorecard is not exist",
+  "deviceId": "Device's ID"
 }

--- a/app/localization/km.json
+++ b/app/localization/km.json
@@ -385,5 +385,6 @@
   "unableToDownloadThePdfFile": "មិនអាចទាញយកឯកសារ PDF",
   "invalidUrl": "URL មិនត្រឹមត្រូវ",
   "incorrectScorecardCode": "លេខកូដប័ណ្ណដាក់ពិន្ទុមិនត្រឹមត្រូវ",
-  "theScorecardIsNotExist": "មិនមានប័ណ្ណដាក់ពិន្ទុ"
+  "theScorecardIsNotExist": "មិនមានប័ណ្ណដាក់ពិន្ទុ",
+  "deviceId": "ID ឧបករណ៍"
 }

--- a/app/screens/About/About.js
+++ b/app/screens/About/About.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { View, Text, Image, ScrollView, Linking, TouchableOpacity } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
+import DeviceInfo from 'react-native-device-info';
 
 import { LocalizationContext } from '../../components/Translations';
 
@@ -14,6 +15,15 @@ const styles = getDeviceStyle(AboutTabletStyles, AboutMobileStyles);
 
 class About extends Component {
   static contextType = LocalizationContext;
+  state = {
+    deviceId: ''
+  }
+
+  async componentDidMount() {
+    await DeviceInfo.getAndroidId().then((androidId) => {
+      this.setState({ deviceId: androidId })
+    });
+  }
 
   buildLogo(logo, index) {
     let mobileHeight = isShortWidthScreen() ? wp('18%') : wp('15%');
@@ -67,8 +77,9 @@ class About extends Component {
           { logos.map((logo, index) => this.buildLogo(logo, index)) }
         </View>
 
-        <View style={{alignSelf: 'flex-end', justifyContent: 'flex-end', marginTop: 26}}>
-          <Text style={styles.versionText}>{translations.version} { pkg.version }</Text>
+        <View style={styles.infoContainer}>
+          <Text style={styles.infoLabel}>{translations.version} { pkg.version }</Text>
+          <Text style={styles.infoLabel}>{ translations.deviceId }: { this.state.deviceId }</Text>
         </View>
       </View>
     );

--- a/app/styles/mobile/AboutScreenStyle.js
+++ b/app/styles/mobile/AboutScreenStyle.js
@@ -51,10 +51,15 @@ const AboutScreenStyles = StyleSheet.create({
     flexDirection: 'row',
     marginTop: -5,
   },
-  versionText: {
-    textAlign: 'center',
-    marginTop: 10,
-    fontSize: contentFontSize
+  infoContainer: {
+    width: '100%',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+    marginTop: 26
+  },
+  infoLabel: {
+    fontSize: contentFontSize,
+    marginBottom: 5
   }
 });
 

--- a/app/styles/tablet/AboutScreenStyle.js
+++ b/app/styles/tablet/AboutScreenStyle.js
@@ -49,10 +49,15 @@ const AboutScreenStyles = StyleSheet.create({
     flexDirection: 'row',
     marginTop: 14
   },
-  versionText: {
-    textAlign: 'center',
-    marginTop: 10,
-    fontSize: contentFontSize
+  infoContainer: {
+    width: '100%',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+    marginTop: 26
+  },
+  infoLabel: {
+    fontSize: contentFontSize,
+    marginBottom: 5
   }
 });
 


### PR DESCRIPTION
This pull request is showing the device id on the setting screen.

Below are the screenshots of the setting screen with device id on mobile and tablet

[device's id.zip](https://github.com/ilabsea/scorecard_mobile/files/9082890/device.s.id.zip)

