### PR TITLE
Send running progress status before submitting scorecard

### DIFF
--- a/app/components/ScorecardProgress/ScorecardProgressButtons.js
+++ b/app/components/ScorecardProgress/ScorecardProgressButtons.js
@@ -13,7 +13,7 @@ import { FontFamily } from '../../assets/stylesheets/theme/font';
 import scorecardHelper from '../../helpers/scorecard_helper';
 import scorecardTracingStepsService from '../../services/scorecard_tracing_steps_service';
 import Scorecard from '../../models/Scorecard';
-import { FINISHED } from '../../constants/milestone_constant';
+import { FINISHED } from '../../constants/scorecard_constant';
 import { getDeviceStyle, containerPadding } from '../../utils/responsive_util';
 import { getMobileFontSizeByPixelRatio } from '../../utils/font_size_util';
 

--- a/app/config/environment.js
+++ b/app/config/environment.js
@@ -1,5 +1,5 @@
 export const environment = {
-  domain: 'http://192.168.1.121:3000',
+  domain: 'http://192.168.0.107:3000',
   type: 'development',
   defaultLanguage: 'km',
   removeScorecardDay: 90,

--- a/app/config/environment.js
+++ b/app/config/environment.js
@@ -1,5 +1,5 @@
 export const environment = {
-  domain: 'http://192.168.0.107:3000',
+  domain: 'http://192.168.1.121:3000',
   type: 'development',
   defaultLanguage: 'km',
   removeScorecardDay: 90,

--- a/app/constants/milestone_constant.js
+++ b/app/constants/milestone_constant.js
@@ -1,7 +1,0 @@
-export const DOWNLOADED = 'downloaded';
-export const RUNNING = 'running';
-export const FINISHED = 'finished';
-export const SUBMITTED = 'submitted';
-export const RENEWED = 'renewed';
-export const IN_REVIEW = 'in_review';
-export const COMPLETED = 'completed';

--- a/app/constants/scorecard_constant.js
+++ b/app/constants/scorecard_constant.js
@@ -66,6 +66,13 @@ const scorecardTrackingSteps = {
 };
 
 const scorecardListSubTitleMobileFontSize = getMobileFontSizeByPixelRatio(11.5, 12);
+const DOWNLOADED = 'downloaded';
+const RUNNING = 'running';
+const FINISHED = 'finished';
+const SUBMITTED = 'submitted';
+const RENEWED = 'renewed';
+const IN_REVIEW = 'in_review';
+const COMPLETED = 'completed';
 
 export {
   scorecardDownloadPhases,
@@ -91,4 +98,11 @@ export {
   SCORECARD_RESULT,
   scorecardTrackingSteps,
   scorecardListSubTitleMobileFontSize,
+  DOWNLOADED,
+  RUNNING,
+  FINISHED,
+  SUBMITTED,
+  RENEWED,
+  IN_REVIEW,
+  COMPLETED,
 };

--- a/app/db/migrations/v17/scorecard.js
+++ b/app/db/migrations/v17/scorecard.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import scorecardProgress from '../../jsons/scorecardProgress';
-import { SUBMITTED } from '../../../constants/milestone_constant';
+import { SUBMITTED } from '../../../constants/scorecard_constant';
 
 class Scorecard {
   get isInLastPhase() {

--- a/app/db/migrations/v19/scorecard.js
+++ b/app/db/migrations/v19/scorecard.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import scorecardProgress from '../../jsons/scorecardProgress';
-import { SUBMITTED } from '../../../constants/milestone_constant';
+import { SUBMITTED } from '../../../constants/scorecard_constant';
 
 class Scorecard {
   get isInLastPhase() {

--- a/app/db/migrations/v20/scorecard.js
+++ b/app/db/migrations/v20/scorecard.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import scorecardProgress from '../../jsons/scorecardProgress';
-import { SUBMITTED } from '../../../constants/milestone_constant';
+import { SUBMITTED } from '../../../constants/scorecard_constant';
 
 class Scorecard {
   get isInLastPhase() {

--- a/app/db/migrations/v21/scorecard.js
+++ b/app/db/migrations/v21/scorecard.js
@@ -1,0 +1,88 @@
+'use strict';
+
+import scorecardProgress from '../../jsons/scorecardProgress';
+import { SUBMITTED } from '../../../constants/scorecard_constant';
+
+class Scorecard {
+  get isInLastPhase() {
+    return this.status == scorecardProgress[scorecardProgress.length - 1].value;
+  }
+
+  get isCompleted() {
+    return this.milestone === SUBMITTED;
+  }
+
+  get isUploaded() {
+    return !!this.uploaded_date;
+  }
+
+  get isDeleted() {
+    return !!this.deleted_date;
+  }
+
+  get isSameLanguageCode() {
+    return this.audio_language_code == this.text_language_code;
+  }
+
+  get subTitle() {
+    let scorecard_type = {community_scorecard: 'CS', self_assessment: 'SA'}[this.scorecard_type];
+
+    return `${this.commune}-${this.district}-${this.province}-${this.year}-${this.facility_code}-${scorecard_type}`;
+  }
+
+  get displayName() {
+    return `${this.uuid} (${this.subTitle})`;
+  }
+}
+
+Scorecard.schema = {
+  name: 'Scorecard',
+  primaryKey: 'uuid',
+  properties: {
+    uuid: 'string',
+    unit_type: 'string',
+    facility_id: 'int',
+    facility: 'string',
+    facility_code: 'string',
+    scorecard_type: 'string',
+    name: 'string',
+    description: 'string?',
+    year: 'int',
+    conducted_date: 'string?',
+    number_of_caf: 'int?',
+    number_of_participant: { type: 'int?', default: 0 },
+    number_of_female: { type: 'int?', default: 0 },
+    number_of_disability: { type: 'int?', default: 0 },
+    number_of_ethnic_minority: { type: 'int?', default: 0 },
+    number_of_youth: { type: 'int?', default: 0 },
+    number_of_id_poor: { type: 'int?', default: 0 },
+    status: { type: 'string', default: '1' },
+    local_ngo_name: 'string',
+    local_ngo_id: 'int',
+    province: 'string',
+    district: 'string',
+    commune: 'string',
+    program_id: 'int',
+    uploaded_date: { type: 'date', optional: true },
+    downloaded: { type: 'bool', default: false },
+    text_language_code: 'string?',
+    audio_language_code: 'string?',
+    deleted_date: 'string?',
+    finished: { type: 'bool', default: false },
+    downloaded_at: 'date',
+    primary_school: 'string?',
+    tour_tip_shown: { type: 'bool', default: false },
+    milestone: 'string?',
+    finished_date: {type: 'date', optional: true},
+    running_date: {type: 'date', optional: true},
+    planned_start_date: {type: 'date', optional: true},
+    planned_end_date: {type: 'date', optional: true},
+    conducted_at: { type: 'date', optional: true },
+    endpoint_url: 'string?',
+    program_uuid: 'string?',
+    proposed_indicator_method: 'int?',         // storing 1 for 'participant_based' and 2 for 'indicator_based'
+    running_status_uploaded: { type: 'bool', default: false }
+  }
+}
+
+export default Scorecard;

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -20,6 +20,7 @@ import schemaV16 from './schemas/schemaV16';
 import schemaV17 from './schemas/schemaV17';
 import schemaV19 from './schemas/v19/schemaV19';
 import schemaV20 from './schemas/v20/schemaV20';
+import schemaV21 from './schemas/schemaV21';
 
 const schemas = [
   schemaV1,
@@ -40,6 +41,7 @@ const schemas = [
   schemaV17,
   schemaV19,
   schemaV20,
+  schemaV21,
 ];
 
 // the first schema to update to is the current schema version

--- a/app/db/schemas/schemaV21.js
+++ b/app/db/schemas/schemaV21.js
@@ -1,0 +1,44 @@
+import ProgramLanguage from '../migrations/v3/programLanguage';
+import Scorecard from '../migrations/v21/scorecard';
+import ProposedIndicator from '../migrations/v12/proposedIndicator';
+import Indicator from '../migrations/v19/indicator';
+import LanguageIndicator from '../migrations/v19/languageIndicator';
+import EndpointUrl from '../migrations/v20/endpointUrl';
+import Rating from '../migrations/v14/rating';
+import VotingIndicator from '../migrations/v14/votingIndicator';
+import Facilitator from '../migrations/v16/facilitator';
+
+import schemaHelper from '../../helpers/schema_helper';
+import { schemaNames } from '../../constants/schema_constant';
+import { DOWNLOADED } from '../../constants/scorecard_constant';
+
+const changedSchemas = [
+  { label: schemaNames[0], data: Scorecard },
+  { label: schemaNames[2], data: Indicator },
+  { label: schemaNames[4], data: LanguageIndicator },
+  { label: schemaNames[5], data: Facilitator },
+  { label: schemaNames[10], data: Rating },
+  { label: schemaNames[13], data: ProgramLanguage },
+  { label: schemaNames[17], data: ProposedIndicator },
+  { label: schemaNames[18], data: VotingIndicator },
+  { label: schemaNames[20], data: EndpointUrl }
+];
+
+const schemaV20 = {
+  schema: schemaHelper.getSchemas(changedSchemas),
+  schemaVersion: 21,
+  migration: (oldRealm, newRealm) => {
+    if (oldRealm.schemaVersion < 21) {
+      const oldScorecards = oldRealm.objects('Scorecard');
+      const newScorecards = newRealm.objects('Scorecard');
+
+      for (let i = 0; i < oldScorecards.length; i ++) {
+        // If the existing scorecard has milestone as null or downloaded, it means the scorecard didn't upload the running milestone yet
+        const isUploaded = (!oldScorecards[i].milestone || oldScorecards[i].milestone == DOWNLOADED) ? false : true;
+        newScorecards[i].running_status_uploaded = !oldScorecards[i].running_status_uploaded ? isUploaded : oldScorecards[i].running_status_uploaded;
+      }
+    }
+  }
+}
+
+export default schemaV20;

--- a/app/helpers/scorecard_helper.js
+++ b/app/helpers/scorecard_helper.js
@@ -2,8 +2,7 @@ import { ERROR_SCORECARD_COMPLETED, ERROR_SCORECARD_EXECUTED } from '../constant
 import Moment from 'moment';
 import moment from "moment/min/moment-with-locales";
 import { environment } from '../config/environment';
-import { selfAssessment } from '../constants/scorecard_constant';
-import { DOWNLOADED, RUNNING, FINISHED, RENEWED, IN_REVIEW } from '../constants/milestone_constant';
+import { selfAssessment, DOWNLOADED, RUNNING, FINISHED, RENEWED } from '../constants/scorecard_constant';
 import Color from '../themes/color';
 import Scorecard from '../models/Scorecard';
 import EndpointUrl from '../models/EndpointUrl';

--- a/app/models/Scorecard.js
+++ b/app/models/Scorecard.js
@@ -1,7 +1,6 @@
 import realm from '../db/schema';
 import AsyncStorage from '@react-native-community/async-storage';
-import { DOWNLOADED, RUNNING, SUBMITTED, IN_REVIEW } from '../constants/milestone_constant';
-import { INDICATOR_DEVELOPMENT } from '../constants/scorecard_constant';
+import { INDICATOR_DEVELOPMENT, DOWNLOADED, RUNNING, SUBMITTED, IN_REVIEW } from '../constants/scorecard_constant';
 import scorecardHelper from '../helpers/scorecard_helper';
 import settingHelper from '../helpers/setting_helper';
 import scorecardDataUtil from '../utils/scorecard_data_util';

--- a/app/screens/ScorecardList/ScorecardList.js
+++ b/app/screens/ScorecardList/ScorecardList.js
@@ -67,6 +67,9 @@ class ScorecardList extends Component {
   }
 
   onPress(scorecard) {
+    // console.log('scorecard milestone = ', scorecard.milestone)
+    console.log('scorecard running status uploaded = ', scorecard.running_status_uploaded)
+
     // Prevent the user from viewing the scorecard detail if the scorecard is deleting
     if (this.state.isDeleting)
       return;

--- a/app/screens/ScorecardList/ScorecardList.js
+++ b/app/screens/ScorecardList/ScorecardList.js
@@ -67,9 +67,6 @@ class ScorecardList extends Component {
   }
 
   onPress(scorecard) {
-    // console.log('scorecard milestone = ', scorecard.milestone)
-    console.log('scorecard running status uploaded = ', scorecard.running_status_uploaded)
-
     // Prevent the user from viewing the scorecard detail if the scorecard is deleting
     if (this.state.isDeleting)
       return;

--- a/app/screens/ScorecardProgress/ScorecardProgress.js
+++ b/app/screens/ScorecardProgress/ScorecardProgress.js
@@ -13,9 +13,12 @@ import ScorecardService from '../../services/scorecardService';
 import internetConnectionService from '../../services/internet_connection_service';
 import scorecardTracingStepsService from '../../services/scorecard_tracing_steps_service';
 import scorecardProgressService from '../../services/scorecard_progress_service';
+import scorecardMilestoneService from '../../services/scorecard_milestone_service';
+import { getErrorType } from '../../services/api_service';
 import Scorecard from '../../models/Scorecard';
 import settingHelper from '../../helpers/setting_helper';
 import { ERROR_SUBMIT_SCORECARD, ERROR_NOT_FOUND } from '../../constants/error_constant';
+import { RUNNING } from '../../constants/scorecard_constant';
 
 import { connect } from 'react-redux';
 
@@ -79,8 +82,18 @@ class ScorecardProgress extends Component {
     });
 
     this.checkScorecardProposeIndicatorMethod(() => {
-      this.uploadScorecard();
+      this.uploadScorecardRunningStatus();
     });
+  }
+
+  uploadScorecardRunningStatus() {
+    const params = {
+      scorecardUuid: this.state.scorecard.uuid,
+      milestone: RUNNING
+    }
+    scorecardMilestoneService.updateMilestone(params, null, () => {
+      this.uploadScorecard();
+    }, (error) => this.handleSubmitError(getErrorType(error.status)));
   }
 
   uploadScorecard() {
@@ -97,15 +110,17 @@ class ScorecardProgress extends Component {
         }, 500);
         scorecardTracingStepsService.trace(this.state.scorecard.uuid, 10);
       }
-    }, (errorType) => {
-      this.setState({
-        visibleModal: true,
-        errorType: errorType != ERROR_NOT_FOUND ? errorType : ERROR_SUBMIT_SCORECARD,
-        showProgress: false,
-      });
-    });
+    }, (errorType) => this.handleSubmitError(errorType));
 
     this.checkSubmitProgress();
+  }
+
+  handleSubmitError(errorType) {
+    this.setState({
+      visibleModal: true,
+      errorType: errorType != ERROR_NOT_FOUND ? errorType : ERROR_SUBMIT_SCORECARD,
+      showProgress: false,
+    });
   }
 
   async checkScorecardProposeIndicatorMethod(callback) {

--- a/app/screens/ScorecardProgress/ScorecardProgress.js
+++ b/app/screens/ScorecardProgress/ScorecardProgress.js
@@ -34,13 +34,10 @@ class ScorecardProgress extends Component {
       visibleModal: false,
       errorType: null,
       hasInternetConnection: false,
-      messageModalTitle: null,
-      messageModalDescription: null,
       isLoading: false,
       hasMatchedEndpointUrl: false,
       isEditable: false,
       isSyncing: false,
-
       progressMessage: '',
     };
     this.unsubscribeNetInfo;
@@ -82,7 +79,11 @@ class ScorecardProgress extends Component {
     });
 
     this.checkScorecardProposeIndicatorMethod(() => {
-      this.uploadScorecardRunningStatus();
+      if (!this.state.scorecard.running_status_uploaded) {
+        this.uploadScorecardRunningStatus();
+        return;
+      }
+      this.uploadScorecard();
     });
   }
 

--- a/app/services/notification_service.js
+++ b/app/services/notification_service.js
@@ -1,6 +1,6 @@
 import messaging from '@react-native-firebase/messaging';
 import Scorecard from '../models/Scorecard';
-import { SUBMITTED, COMPLETED } from '../constants/milestone_constant';
+import { SUBMITTED, COMPLETED } from '../constants/scorecard_constant';
 import { navigationRef } from '../navigators/app_navigator';
 
 const notificationService = (() => {

--- a/app/services/scorecardService.js
+++ b/app/services/scorecardService.js
@@ -10,7 +10,7 @@ import ScorecardReference from '../models/ScorecardReference';
 
 import { scorecardAttributes } from '../utils/scorecard_attributes_util';
 import { handleApiResponse, sendRequestToApi } from './api_service';
-import { IN_REVIEW } from '../constants/milestone_constant';
+import { IN_REVIEW } from '../constants/scorecard_constant';
 
 class ScorecardService {
 

--- a/app/services/scorecard_deletion_service.js
+++ b/app/services/scorecard_deletion_service.js
@@ -12,7 +12,7 @@ import proposedIndicatorService from './proposed_indicator_service';
 import scorecardSharingService from './scorecard_sharing_service';
 import customIndicatorService from './custom_indicator_service';
 
-import { RENEWED } from '../constants/milestone_constant';
+import { RENEWED } from '../constants/scorecard_constant';
 
 const scorecardDeletionService = (() => {
   return {

--- a/app/services/scorecard_download_service.js
+++ b/app/services/scorecard_download_service.js
@@ -1,7 +1,7 @@
 import realm from '../db/schema';
 import { getEachPhasePercentage } from '../utils/scorecard_detail_util';
 
-import { scorecardDownloadPhases, languageIndicatorPhase } from '../constants/scorecard_constant';
+import { scorecardDownloadPhases, languageIndicatorPhase, DOWNLOADED } from '../constants/scorecard_constant';
 
 import IndicatorService from './indicator_service';
 import { save as saveCaf } from './caf_service';
@@ -11,9 +11,6 @@ import { LanguageIndicatorService } from './language_indicator_service';
 import { LanguageRatingScaleService } from './language_rating_scale_service';
 import scorecardMilestoneService from './scorecard_milestone_service';
 import scorecardTracingStepsService from './scorecard_tracing_steps_service';
-
-import { DOWNLOADED } from '../constants/milestone_constant';
-
 
 const find = (scorecardUuid) => {
   return realm.objects('ScorecardDownload').filtered(`scorecard_uuid == '${scorecardUuid}'`)[0];

--- a/app/services/scorecard_milestone_service.js
+++ b/app/services/scorecard_milestone_service.js
@@ -21,7 +21,11 @@ const scorecardMilestoneService = (() => {
     ScorecardProgressApi.post(await _getScorecardAttrs(params, data))
       .then(function (response) {
         if (response.status == 200) {
-          Scorecard.update(scorecardUuid, { milestone: milestone });
+          const attrs = { milestone: milestone }
+          if (milestone == RUNNING)
+            attrs['running_status_uploaded'] = true;
+
+          Scorecard.update(scorecardUuid, attrs);
           callback && callback();
         }
         else

--- a/app/services/scorecard_milestone_service.js
+++ b/app/services/scorecard_milestone_service.js
@@ -1,7 +1,7 @@
 import DeviceInfo from 'react-native-device-info';
 import Scorecard from '../models/Scorecard';
 import ScorecardProgressApi from '../api/ScorecardProgressApi';
-import { RUNNING, RENEWED } from '../constants/milestone_constant';
+import { RUNNING, RENEWED } from '../constants/scorecard_constant';
 
 const scorecardMilestoneService = (() => {
   return {

--- a/app/services/scorecard_preference_service.js
+++ b/app/services/scorecard_preference_service.js
@@ -9,7 +9,7 @@ import ProgramLanguage from '../models/ProgramLanguage';
 
 import { currentDateTime } from '../utils/date_util';
 import { isKhmerLanguage } from '../utils/program_language_util';
-import { RUNNING } from '../constants/milestone_constant';
+import { RUNNING } from '../constants/scorecard_constant';
 
 const scorecardPreferenceService = (() => {
   return {

--- a/app/services/scorecard_sync_service.js
+++ b/app/services/scorecard_sync_service.js
@@ -3,7 +3,7 @@ import NetInfo from '@react-native-community/netinfo';
 import Scorecard from '../models/Scorecard';
 import ScorecardService from './scorecardService';
 import { apiDateFormat } from '../constants/date_format_constant';
-import { SUBMITTED, COMPLETED } from '../constants/milestone_constant';
+import { SUBMITTED, COMPLETED } from '../constants/scorecard_constant';
 import settingHelper from '../helpers/setting_helper';
 
 const scorecardSyncService = (() => {

--- a/app/utils/scorecard_util.js
+++ b/app/utils/scorecard_util.js
@@ -5,7 +5,7 @@ import urlUtil from './url_util';
 import { isNumber } from './string_util';
 import { validScorecardUrls } from '../constants/url_constant';
 import { ERROR_INVALID_SCORECARD_URL } from '../constants/error_constant';
-import { IN_REVIEW } from '../constants/milestone_constant';
+import { IN_REVIEW } from '../constants/scorecard_constant';
 import { INVALID_SCORECARD_ATTEMPT } from '../constants/lock_device_constant';
 import lockDeviceService from '../services/lock_device_service';
 


### PR DESCRIPTION
This pull request is making enhancements and changes:
- Upload the RUNNING status (scorecard progress) before submitting the scorecard if the scorecard doesn't upload the RUNNING status yet
- Move the milestone constants to scorecard_constant.js

** Migration to handle the existing scorecard:
- If the existing scorecard has milestone = null (scorecard is joined but is not downloaded the data yet) or milestone = DOWNLOADED, we will mark the scorecard as not uploading the RUNNING status yet
- If the existing scorecard has milestone = RUNNING, we will mark the RUNNING status as uploaded in this scorecard