### PR TITLE
Hot-fix the style breaking in scorecard list screen on the mobile wit…

### DIFF
--- a/app/components/ScorecardList/ScorecardListInfo.js
+++ b/app/components/ScorecardList/ScorecardListInfo.js
@@ -3,12 +3,13 @@ import { View } from 'react-native';
 
 import ScorecardListInfoDetail from './ScorecardListInfoDetail';
 import ScorecardListInfoLocation from './ScorecardListInfoLocation';
+import { getDeviceStyle } from '../../utils/responsive_util';
 class ScorecardListInfo extends Component {
   render() {
     const scorecard = this.props.scorecard || {};
 
     return (
-      <View style={{flex: 1, marginLeft: 15}}>
+      <View style={{flex: 1, marginLeft: getDeviceStyle(15, 10)}}>
         <ScorecardListInfoDetail scorecard={scorecard} />
 
         <ScorecardListInfoLocation scorecard={scorecard} />

--- a/app/components/ScorecardList/ScorecardListInfoDetail.js
+++ b/app/components/ScorecardList/ScorecardListInfoDetail.js
@@ -9,8 +9,9 @@ import EndpointBadge from '../Share/EndpointBadge';
 import VotingIndicator from '../../models/VotingIndicator';
 import scorecardHelper from '../../helpers/scorecard_helper';
 import { getDeviceStyle } from '../../utils/responsive_util';
+import { scorecardListSubTitleMobileFontSize } from '../../constants/scorecard_constant';
 
-const subTextFontSize = getDeviceStyle(13, 12);
+const subTextFontSize = getDeviceStyle(13, scorecardListSubTitleMobileFontSize);
 
 class ScorecardListInfoDetail extends Component {
   static contextType = LocalizationContext;

--- a/app/components/ScorecardList/ScorecardListInfoLocation.js
+++ b/app/components/ScorecardList/ScorecardListInfoLocation.js
@@ -20,7 +20,7 @@ class ScorecardListInfoLocation extends Component {
   renderPrimarySchool() {
     return (
       <Text style={responsiveStyles.locationLabel}>
-        { JSON.parse(this.props.scorecard.primary_school)[`name_${this.context.appLanguage}`] }{`, `}
+        { JSON.parse(this.props.scorecard.primary_school)[`name_${this.context.appLanguage}`] }
       </Text>
     )
   }
@@ -35,7 +35,7 @@ class ScorecardListInfoLocation extends Component {
           { scorecard.primary_school && this.renderPrimarySchool(scorecard) }
 
           <Text numberOfLines={1} style={[responsiveStyles.locationLabel, { maxWidth: getLocationMaxWidth(scorecard, this.context.appLanguage)}]}>
-            { scorecard.commune }, { scorecard.district }
+            { this.props.scorecard.primary_school && `, `}{ scorecard.commune }, { scorecard.district }
           </Text>
           <Text style={responsiveStyles.locationLabel}>, {scorecard.province}</Text>
         </View>

--- a/app/components/Share/EndpointBadge.js
+++ b/app/components/Share/EndpointBadge.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 
 import endpointUrlHelper from '../../helpers/endpoint_url_helper';
+import { isShortWidthScreen } from '../../utils/responsive_util';
 
 const EndpointBadge = (props) => {
   const {shortcut, shortcut_bg_color, shortcut_text_color} = props.endpoint;
@@ -16,14 +17,14 @@ const EndpointBadge = (props) => {
 const styles = StyleSheet.create({
   badge: {
     paddingHorizontal: 4,
-    marginLeft: 20,
+    marginLeft: isShortWidthScreen() ? 4 : 20,
     borderRadius: 4,
     justifyContent: 'center',
     alignItems: 'center',
     height: 20
   },
   badgeLabel: {
-    fontSize: 11,
+    fontSize: isShortWidthScreen() ? 10 : 11,
     textTransform: 'uppercase'
   }
 });

--- a/app/constants/scorecard_constant.js
+++ b/app/constants/scorecard_constant.js
@@ -1,3 +1,5 @@
+import { getMobileFontSizeByPixelRatio } from '../utils/font_size_util';
+
 // Download phases of scorecard contain indicator, language_indicator, caf,
 // rating_scale, program_language, lang_indicator_audio, lang_rating_scale_audio, and indicator_image
 const scorecardDownloadSteps = 6;
@@ -63,6 +65,8 @@ const scorecardTrackingSteps = {
   12: 'propose_by_participant_base',
 };
 
+const scorecardListSubTitleMobileFontSize = getMobileFontSizeByPixelRatio(11.5, 12);
+
 export {
   scorecardDownloadPhases,
   indicatorPhase,
@@ -86,4 +90,5 @@ export {
   VOTING,
   SCORECARD_RESULT,
   scorecardTrackingSteps,
+  scorecardListSubTitleMobileFontSize,
 };

--- a/app/styles/mobile/ScorecardItemComponentStyle.js
+++ b/app/styles/mobile/ScorecardItemComponentStyle.js
@@ -2,10 +2,10 @@ import { StyleSheet } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import { FontFamily } from '../../assets/stylesheets/theme/font';
 import { smLabelSize, xlIconSize } from '../../constants/mobile_font_size_constant';
+import { scorecardListSubTitleMobileFontSize } from '../../constants/scorecard_constant';
 import Color from '../../themes/color';
-import { bodyFontSize, getMobileFontSizeByPixelRatio } from '../../utils/font_size_util';
-
-const subTitleFontSize = getMobileFontSizeByPixelRatio(12, 11.5);
+import { bodyFontSize } from '../../utils/font_size_util';
+import { isShortWidthScreen } from '../../utils/responsive_util';
 
 const ScorecardItemComponentStyles = StyleSheet.create({
   itemContainer: {
@@ -61,7 +61,7 @@ const ScorecardItemComponentStyles = StyleSheet.create({
     fontSize: bodyFontSize(),
   },
   locationLabel: {
-    fontSize: subTitleFontSize,
+    fontSize: scorecardListSubTitleMobileFontSize,
     marginLeft: 4,
     color: Color.grayColor,
     marginRight: 0,
@@ -77,11 +77,11 @@ const ScorecardItemComponentStyles = StyleSheet.create({
     borderRadius: 30, 
   },
   removeDateIcon: {
-    marginTop: 5,
+    marginTop: isShortWidthScreen() ? 4 : 5,
     marginRight: 4
   },
   removeDateLabel: {
-    fontSize: subTitleFontSize,
+    fontSize: scorecardListSubTitleMobileFontSize,
     color: Color.redColor,
     fontFamily: FontFamily.body,
     textAlign: 'right',


### PR DESCRIPTION
This pull request is making a hot-fix on the breaking style of the scorecard card item in the scorecard list screen when running on a mobile device with a smaller width.

Below are the screenshots of the scorecard list screen on the smaller width mobile and normal width mobile:
[scorecard list.zip](https://github.com/ilabsea/scorecard_mobile/files/9205160/scorecard.list.zip)

