### PR TITLE
Remove add new endpoint button on the endpoint url picker

### DIFF
--- a/app/components/Setting/SettingUrlEndpointPicker.js
+++ b/app/components/Setting/SettingUrlEndpointPicker.js
@@ -97,7 +97,7 @@ class SettingUrlEndpointPicker extends React.Component {
             onPressRightButton={() => navigate('AddNewEndpointUrl')}
             onPressBottomButton={() => this.changeSelectedEndpoint()}
             showConfirmDelete={(item) => this.showConfirmDelete(item)}
-            hasAddButton={true}
+            hasAddButton={false}
             hasBottomButton={true}
             bottomInfoMessage={<SettingUrlEndpointWarningMessages/>}
             isSelctedItemMatched={(selectedEndpoint) => selectedEndpoint === this.props.selectedEndpointUrl}


### PR DESCRIPTION
This pull request is hiding the add new endpoint URL button on the endpoint URL picker in the setting screen.
![Screenshot_20220729-103455](https://user-images.githubusercontent.com/18114944/181677786-adc4f8e7-95cc-47cb-99b3-79f4c6fb79e8.jpg)

