### PR TITLE
Update the audio icon to outline style

### DIFF
--- a/app/components/Share/PlaySound.js
+++ b/app/components/Share/PlaySound.js
@@ -93,10 +93,10 @@ class PlaySound extends Component {
 
   getIconName() {
     if (!this.props.filePath) {
-      return 'volume-mute';
+      return 'volume-mute-outline';
     }
 
-    return this.state.playState == 'playing' ? 'pause' : 'volume-medium';
+    return this.state.playState == 'playing' ? 'pause' : 'volume-medium-outline';
   }
 
   render() {


### PR DESCRIPTION
This pull request is updating the audio icon to outline style.
![indicator development screen](https://user-images.githubusercontent.com/18114944/181736419-cb8a41f6-1be3-4102-a5b3-d9d17d5c63e6.jpg)
![proposed indicator screen](https://user-images.githubusercontent.com/18114944/181736455-87e45258-f99b-4238-b2a3-a9da6fb0c06b.jpg)
![voting screen](https://user-images.githubusercontent.com/18114944/181736466-07c073e9-b058-4d95-a1fa-3478dbd88d50.jpg)

