### PR TITLE
Disable the confirm delete button while the scorecard is deleting

### DIFF
--- a/app/components/ScorecardList/ScorecardListModals.js
+++ b/app/components/ScorecardList/ScorecardListModals.js
@@ -27,7 +27,7 @@ class ScorecardListModals extends Component {
           closeButtonLabel={this.props.isConfirmModal ? translations.close : translations.infoCloseLabel}
           hasConfirmButton={this.props.isConfirmModal}
           confirmButtonLabel={translations.ok}
-          isConfirmButtonDisabled={false}
+          isConfirmButtonDisabled={this.props.isDeleting}
           onDismiss={() => this.props.onConfirmModalDismiss()}
           onConfirm={() => this.props.confirmDelete()}
         />

--- a/app/screens/ScorecardList/ScorecardList.js
+++ b/app/screens/ScorecardList/ScorecardList.js
@@ -107,6 +107,7 @@ class ScorecardList extends Component {
         isConfirmModal: isErrorUnauthorize,
         visibleModal: !isErrorUnauthorize,
         visibleErrorModal: isErrorUnauthorize,
+        isDeleting: false
       });
     });
   }
@@ -151,6 +152,7 @@ class ScorecardList extends Component {
           confirmDelete={() => this._confirmDelete()}
           headerHeight={this.state.headerHeight}
           scorecards={this.state.scorecards}
+          isDeleting={this.state.isDeleting}
         />
       </View>
     )


### PR DESCRIPTION
This pull request is to disable the confirm to delete button while deleting the scorecard in order to prevent the user from clicking the confirm to delete button multiple times constantly which will cause the error of accessing the deleted data.