### PR TITLE
Prevent the user from continuing the scorecard with unmatched endpoin…

### DIFF
--- a/app/components/Share/ErrorAlertMessage.js
+++ b/app/components/Share/ErrorAlertMessage.js
@@ -6,7 +6,7 @@ import CustomAlertMessage from './CustomAlertMessage';
 import CustomAlertMessageBigButton from './CustomAlertMessage/CustomAlertMessageBigButton';
 
 import { getAlertMessageObject } from '../../utils/alert_message_util';
-import { ERROR_AUTHENTICATION, RE_LOGIN_REQUIRED } from '../../constants/error_constant';
+import { ERROR_AUTHENTICATION, RE_LOGIN_REQUIRED, MISMATCHED_ENDPOINT } from '../../constants/error_constant';
 import { environment } from '../../config/environment';
 import { navigate } from '../../navigators/app_navigator';
 
@@ -46,7 +46,7 @@ class ErrorAlertMessage extends React.Component {
   }
 
   bigButton() {
-    if (this.props.errorType === RE_LOGIN_REQUIRED || this.props.errorType == ERROR_AUTHENTICATION)
+    if (this.props.errorType === RE_LOGIN_REQUIRED || this.props.errorType == ERROR_AUTHENTICATION || this.props.errorType == MISMATCHED_ENDPOINT)
       return <CustomAlertMessageBigButton
                 label={this.context.translations.goToSetting}
                 onPress={() => this.goToSetting()}

--- a/app/services/deep_link_service.js
+++ b/app/services/deep_link_service.js
@@ -75,12 +75,12 @@ const deepLinkService = (() => {
     _redirectTo('ScorecardDetail', { scorecard_uuid: scorecardUuid });
   }
 
-  function _handleExistingScorecard(scorecardUuid, closeModal, handleOccupiedScorecard) {
+  async function _handleExistingScorecard(scorecardUuid, closeModal, handleOccupiedScorecard) {
     resetLockService.resetLockData(INVALID_SCORECARD_ATTEMPT);
     const scorecard = Scorecard.find(scorecardUuid);
     closeModal();
 
-    if (scorecard.isUploaded || scorecard.finished) {
+    if (scorecard.isUploaded || scorecard.finished || !await Scorecard.isEditable(scorecard)) {
       handleOccupiedScorecard(scorecard);
       return;
     }

--- a/app/services/new_scorecard_service.js
+++ b/app/services/new_scorecard_service.js
@@ -23,10 +23,11 @@ const newScorecardService = (() => {
     return validationService('scorecardCode', scorecardUuid) ? false : true;
   }
 
-  function handleExistedScorecard(scorecardUuid, isDownloadedCallback, notDownloadedCallback) {
+  async function handleExistedScorecard(scorecardUuid, isDownloadedCallback, notDownloadedCallback) {
     AsyncStorage.setItem('SELECTED_SCORECARD_UUID', scorecardUuid);
+    const scorecard = Scorecard.find(scorecardUuid);
 
-    if (!isDownloaded(scorecardUuid)) {
+    if (!isDownloaded(scorecardUuid) && await Scorecard.isEditable(scorecard)) {
       isDownloadedCallback();
       return;
     }


### PR DESCRIPTION
This pull request is preventing the user from continuing the scorecard that has an unmatched endpoint URL when they use the deep link with the scorecard code to open the app.

 When the user uses the deep link with the scorecard code that has an unmatched endpoint URL to open the app, it will redirect the user to the scorecard progress screen.