### PR TITLE
Downgrade the version of react-native-reanimated library

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-native-paper": "^4.4.1",
     "react-native-pell-rich-editor": "^1.3.0",
     "react-native-progress": "^5.0.0",
-    "react-native-reanimated": "^2.10.0",
+    "react-native-reanimated": "^1.13.0",
     "react-native-render-html": "^4.2.4",
     "react-native-responsive-screen": "^1.4.2",
     "react-native-safe-area-context": "^3.1.7",


### PR DESCRIPTION
This pull request is downgrading the version of react-native-reanimated from v2.10.0 to v1.13.0 because the higher version causing the error when building the app.