### PR TITLE
Upgrade the compileSdkVersion and targetSdkVersion to v31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 31
+        targetSdkVersion = 31
         ndkVersion = '21.3.6528147'
     }
     repositories {


### PR DESCRIPTION
This pull request is upgrading the version of compileSdkVersion and targetSdkVersion from 30 to 31 because Google Play Console requires a minimum version of 31 for uploading a new app bundle.

Note: After updating to v31 the unsupported device is 0 (reported by Google Play Console).