### PR TITLE
Update proposed indicator header UI

### DIFF
--- a/app/components/AccordionSwitcher/AccordionSwitcher.js
+++ b/app/components/AccordionSwitcher/AccordionSwitcher.js
@@ -26,7 +26,7 @@ class AccordionSwitcher extends Component {
     const indicators = proposedIndicatorService.getProposedIndicators(this.props.scorecardUuid);
 
     return (
-      <View style={{flexDirection: 'row', marginTop: 20, justifyContent: 'center'}}>
+      <View style={{flexDirection: 'row', marginTop: 6, justifyContent: 'center'}}>
         { this.renderButton(responsiveStyles.btnLeft, ACCORDION_LEFT, this.props.leftLabel, this.props.numberOfProposedParticipant) }
         { this.renderButton(responsiveStyles.btnRight, ACCORDION_RIGHT, this.props.rightLabel, indicators.length) }
       </View>

--- a/app/components/NavigationHeaderBody.js
+++ b/app/components/NavigationHeaderBody.js
@@ -7,7 +7,7 @@ import { navigationHeaderTitleFontSize } from '../utils/font_size_util';
 
 const NavigationHeaderBody = (props) => {
   return (
-    <Body style={{flex: getDeviceStyle(2, 1), paddingLeft: navigationTitlePaddingLeft}}>
+    <Body style={{flex: getDeviceStyle(2, 1), paddingLeft: navigationTitlePaddingLeft, alignItems: 'flex-start'}}>
       <Title style={{fontSize: navigationHeaderTitleFontSize(), fontFamily: FontFamily.title, textTransform: 'capitalize'}}>
         { props.title }
       </Title>

--- a/app/components/ProposedIndicator/ListUser.js
+++ b/app/components/ProposedIndicator/ListUser.js
@@ -52,6 +52,13 @@ class ListUser extends Component {
     const {translations} = this.context;
     const proposedParticipants = Participant.getProposedParticipants(this.props.scorecardUuid);
 
+    const addNewButtonTop = this.props.scrollY.interpolate({
+      inputRange: [0, 100, 150],
+      outputRange: [0, 0, 1],
+      extrapolate: 'clamp',
+      useNativeDriver: true,
+    })
+
     return (
       <View>
         <View style={styles.headingContainer}>

--- a/app/components/ProposedIndicator/ListUser.js
+++ b/app/components/ProposedIndicator/ListUser.js
@@ -23,55 +23,15 @@ class ListUser extends Component {
     }
   }
 
-  renderAnonymous() {
-    const anonymous = Participant.getAnonymousByScorecard(this.props.scorecardUuid).length;
-    if (anonymous > 0)
-      return ` (${this.context.translations.anonymous} ${anonymous})`;
-  }
-
   render() {
-    const {translations} = this.context;
     const proposedParticipants = Participant.getProposedParticipants(this.props.scorecardUuid);
-
-    const addNewButtonTop = this.props.scrollY.interpolate({
-      inputRange: [0, 100, 150],
-      outputRange: [0, 0, 1],
-      extrapolate: 'clamp',
-      useNativeDriver: true,
-    })
-
-    return (
-      <View>
-        <View style={styles.headingContainer}>
-          <Text style={[styles.headingTitle, responsiveStyles.headingTitle]}>
-            { translations.numberOfParticipant }: { Participant.getAllByScorecard(this.props.scorecardUuid).length } {translations.pax}
-            { this.renderAnonymous() }
-          </Text>
-
-          <View style={{flexGrow: 1, alignItems: 'flex-end'}}>
-            <ParticipantInfo
-              title={translations.proposeTheIndicator}
-              participants={Participant.getNotRaised(this.props.scorecardUuid)}
-              scorecardUuid={ this.props.scorecardUuid }
-              buttonVisible={proposedParticipants.length > 0}
-              mode={{type: 'button', label: translations.proposeNewIndicator, iconName: 'plus'}}
-              selectParticipant={(participant) => navigate('CreateNewIndicator', {scorecard_uuid: this.props.scorecardUuid, participant_uuid: participant.uuid})}
-              closeModal={() => this.closeModal()}
-              participantModalRef={this.props.participantModalRef}
-              formModalRef={this.props.formModalRef}
-            />
-          </View>
-        </View>
-
-        <ProposedIndicatorAccordions
-          scorecardUuid={this.props.scorecardUuid}
-          proposedParticipants={proposedParticipants}
-          numberOfProposedParticipant={this.props.numberOfProposedParticipant}
-          showModal={() => this.props.updateModalVisible(true)}
-          startProposeIndicator={() => this.startProposeIndicator()}
-        />
-      </View>
-    );
+    return <ProposedIndicatorAccordions
+              scorecardUuid={this.props.scorecardUuid}
+              proposedParticipants={proposedParticipants}
+              numberOfProposedParticipant={this.props.numberOfProposedParticipant}
+              showModal={() => this.props.updateModalVisible(true)}
+              startProposeIndicator={() => this.startProposeIndicator()}
+           />
   }
 }
 

--- a/app/components/ProposedIndicator/ListUser.js
+++ b/app/components/ProposedIndicator/ListUser.js
@@ -1,33 +1,14 @@
 import React, {Component} from 'react';
-import {View, StyleSheet} from 'react-native';
-import {Text} from 'native-base';
 
-import {LocalizationContext} from '../Translations';
 import ProposedIndicatorAccordions from './ProposedIndicatorAccordions';
-
 import { connect } from 'react-redux';
-import { FontFamily } from '../../assets/stylesheets/theme/font';
-
-import ParticipantInfo from '../CreateNewIndicator/ParticipantInfo';
 import Participant from '../../models/Participant';
 import { navigate } from '../../navigators/app_navigator';
 import proposedIndicatorHelper from '../../helpers/proposed_indicator_helper';
 
 import { isProposeByIndicatorBase } from '../../utils/proposed_indicator_util';
-import { getDeviceStyle } from '../../utils/responsive_util';
-import ProposedIndicatorTabletStyles from '../../styles/tablet/ProposedIndicatorComponentStyle';
-import ProposedIndicatorMobileStyles from '../../styles/mobile/ProposedIndicatorComponentStyle';
-
-const responsiveStyles = getDeviceStyle(ProposedIndicatorTabletStyles, ProposedIndicatorMobileStyles);
 
 class ListUser extends Component {
-  static contextType = LocalizationContext;
-
-  closeModal() {
-    this.props.updateModalVisible(false)
-    this.props.participantModalRef.current?.dismiss();
-  }
-
   _goToCreateNewIndicator(participant_uuid) {
     const params = !!participant_uuid ? { scorecard_uuid: this.props.scorecardUuid, participant_uuid: participant_uuid } : { scorecard_uuid: this.props.scorecardUuid };
     navigate('CreateNewIndicator', params);
@@ -93,19 +74,6 @@ class ListUser extends Component {
     );
   }
 }
-
-const styles = StyleSheet.create({
-  headingContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-  },
-  headingTitle: {
-    fontSize: 20,
-    fontFamily: FontFamily.title,
-    color: '#22354c',
-  },
-});
 
 function mapStateToProps(state) {
   return {participants: state.participantReducer.participants};

--- a/app/components/ProposedIndicator/ProposedIndicatorAccordions.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorAccordions.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
+import {heightPercentageToDP as hp} from 'react-native-responsive-screen';
 
 import {LocalizationContext} from '../Translations';
 import AccordionSwitcher from '../AccordionSwitcher/AccordionSwitcher';
@@ -8,7 +9,6 @@ import IndicatorAccordion from '../IndicatorAccordion/IndicatorAccordion';
 import EmptyListAction from '../Share/EmptyListAction';
 
 import { ACCORDION_LEFT, ACCORDION_RIGHT } from '../../constants/main_constant';
-
 import { isProposeByIndicatorBase } from '../../utils/proposed_indicator_util';
 import { getDeviceStyle } from '../../utils/responsive_util';
 import ProposedIndicatorTabletStyles from '../../styles/tablet/ProposedIndicatorComponentStyle';
@@ -48,7 +48,7 @@ class ProposedIndicatorAccordions extends Component {
     const {translations} = this.context;
 
     return (
-      <View style={{height: '100%'}}>
+      <View style={{height: '100%', paddingTop: hp('10%')}}>
         <EmptyListAction
           title={translations.pleaseProposeIndicator}
           buttonLabel={translations.proposeNewIndicator}

--- a/app/components/ProposedIndicator/ProposedIndicatorMain.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorMain.js
@@ -1,7 +1,9 @@
 import React, {Component} from 'react';
-import {View, StyleSheet, ScrollView} from 'react-native';
+import {Animated, View, StyleSheet, ScrollView} from 'react-native';
 
 import Color from '../../themes/color';
+
+import ProposedIndicatorNavHeader from './ProposedIndicatorNavHeader';
 
 import Tip from '../Share/Tip';
 import ListUser from './ListUser';
@@ -19,6 +21,10 @@ import settingHelper from '../../helpers/setting_helper';
 
 class ProposedIndicatorContent extends Component {
   static contextType = LocalizationContext;
+  constructor(props) {
+    super(props)
+    this.scrollY = new Animated.Value(0)
+  }
 
   componentDidMount() {
     this.props.setSelectedIndicators([])
@@ -55,7 +61,10 @@ class ProposedIndicatorContent extends Component {
   render() {
     return (
       <View style={{flex: 1}}>
-        <ScrollView contentContainerStyle={{padding: containerPadding, paddingBottom: 28, flexGrow: 1}}>
+        <ProposedIndicatorNavHeader scrollY={this.scrollY}/>
+        <ScrollView contentContainerStyle={{padding: containerPadding, paddingBottom: 228, flexGrow: 1, marginTop: 156}}
+          onScroll={Animated.event([{nativeEvent: {contentOffset: {y: this.scrollY}}}], { useNativeDriver: false })}
+        >
           <Tip screenName='ProposedIndicator' showTipModal={() => this.props.tipModalRef.current?.present()} />
 
           <ListUser

--- a/app/components/ProposedIndicator/ProposedIndicatorMain.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorMain.js
@@ -1,10 +1,8 @@
 import React, {Component} from 'react';
-import {Animated, View, StyleSheet, ScrollView} from 'react-native';
-
-import Color from '../../themes/color';
+import {Animated, View, ScrollView} from 'react-native';
 
 import ProposedIndicatorNavHeader from './ProposedIndicatorNavHeader';
-
+import ProposedIndicatorNewProposeButton from './ProposedIndicatorNewProposeButton';
 import Tip from '../Share/Tip';
 import ListUser from './ListUser';
 import BottomButton from '../BottomButton';
@@ -19,11 +17,14 @@ import { containerPadding } from '../../utils/responsive_util';
 import { navigate } from '../../navigators/app_navigator';
 import settingHelper from '../../helpers/setting_helper';
 
+const headerShrinkOffset = 93
+
 class ProposedIndicatorContent extends Component {
   static contextType = LocalizationContext;
   constructor(props) {
     super(props)
     this.scrollY = new Animated.Value(0)
+    this.isHeaderShrunk = false
   }
 
   componentDidMount() {
@@ -45,60 +46,60 @@ class ProposedIndicatorContent extends Component {
   }
 
   renderFinishButton = () => {
-    const {translations} = this.context;
-
     return (
-      <View style={styles.buttonContainer}>
+      <View style={{padding: containerPadding}}>
         <BottomButton
           disabled={!proposedIndicatorService.hasProposedIndicator(this.props.scorecardUuid)}
-          label={translations['finishAndNext']}
+          label={this.context.translations['finishAndNext']}
           onPress={() => this.onPress()}
         />
       </View>
     );
   }
 
+  renderAddNewBtn = () => {
+    return <ProposedIndicatorNewProposeButton
+              scorecardUuid={this.props.scorecardUuid}
+              visibleModal={this.props.visibleModal}
+              participantModalRef={this.props.participantModalRef}
+              formModalRef={this.props.formModalRef}
+              updateModalVisible={(status) => this.props.updateModalVisible(status)}
+           />
+  }
+
   render() {
+    const containerPaddingTop = this.scrollY.interpolate({
+      inputRange: [0, 100, 140],
+      outputRange: [156, 80, 66],
+      extrapolate: 'clamp',
+    })
+
     return (
-      <View style={{flex: 1}}>
-        <ProposedIndicatorNavHeader scrollY={this.scrollY} showTipModal={() => this.props.tipModalRef.current?.present()}/>
-        <ScrollView contentContainerStyle={{padding: containerPadding, paddingBottom: 228, flexGrow: 1, marginTop: 156}}
-          onScroll={Animated.event([{nativeEvent: {contentOffset: {y: this.scrollY}}}], { useNativeDriver: false })}
-        >
-          <Tip screenName='ProposedIndicator' showTipModal={() => this.props.tipModalRef.current?.present()} />
+      <View style={{flexGrow: 1}}>
+        <ProposedIndicatorNavHeader scrollY={this.scrollY} showTipModal={() => !!this.isHeaderShrunk && this.props.tipModalRef.current?.present()}/>
+        <Animated.View style={{flex: 1, paddingTop: containerPaddingTop}}>
+          <ScrollView contentContainerStyle={{padding: containerPadding, paddingBottom: 16, flexGrow: 1}}
+            onScroll={Animated.event([{nativeEvent: {contentOffset: {y: this.scrollY}}}],
+                     { listener: (event) => {this.isHeaderShrunk = event.nativeEvent.contentOffset.y >= headerShrinkOffset}, useNativeDriver: false })}
+            stickyHeaderIndices={[1]}
+          >
+            <Tip screenName='ProposedIndicator' showTipModal={() => this.props.tipModalRef.current?.present()} />
+            {this.renderAddNewBtn()}
+            <ListUser
+              scorecardUuid={this.props.scorecardUuid}
+              numberOfProposedParticipant={Participant.getNumberOfProposedParticipant(this.props.scorecardUuid)}
+              participantModalRef={this.props.participantModalRef}
+              formModalRef={this.props.formModalRef}
+              updateModalVisible={(status) => this.props.updateModalVisible(status)}
+            />
+          </ScrollView>
 
-          <ListUser
-            scorecardUuid={this.props.scorecardUuid}
-            numberOfParticipant={Participant.getAllByScorecard(this.props.scorecardUuid).length}
-            numberOfProposedParticipant={Participant.getProposedParticipants(this.props.scorecardUuid).length}
-            visibleModal={this.props.visibleModal}
-            participantModalRef={this.props.participantModalRef}
-            formModalRef={this.props.formModalRef}
-            updateModalVisible={(status) => this.props.updateModalVisible(status)}
-            scrollY={this.scrollY}
-          />
-        </ScrollView>
-
-        { this.renderFinishButton() }
+          { this.renderFinishButton() }
+        </Animated.View>
       </View>
     );
   }
 }
-
-const styles = StyleSheet.create({
-  headingTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
-  },
-  buttonContainer: {
-    padding: containerPadding
-  },
-  buttonLabelStyle: {
-    textTransform: 'uppercase',
-    fontWeight: 'bold',
-    color: Color.whiteColor,
-  },
-});
 
 function mapStateToProps(state) {
   return {

--- a/app/components/ProposedIndicator/ProposedIndicatorMain.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorMain.js
@@ -61,7 +61,7 @@ class ProposedIndicatorContent extends Component {
   render() {
     return (
       <View style={{flex: 1}}>
-        <ProposedIndicatorNavHeader scrollY={this.scrollY}/>
+        <ProposedIndicatorNavHeader scrollY={this.scrollY} showTipModal={() => this.props.tipModalRef.current?.present()}/>
         <ScrollView contentContainerStyle={{padding: containerPadding, paddingBottom: 228, flexGrow: 1, marginTop: 156}}
           onScroll={Animated.event([{nativeEvent: {contentOffset: {y: this.scrollY}}}], { useNativeDriver: false })}
         >
@@ -75,6 +75,7 @@ class ProposedIndicatorContent extends Component {
             participantModalRef={this.props.participantModalRef}
             formModalRef={this.props.formModalRef}
             updateModalVisible={(status) => this.props.updateModalVisible(status)}
+            scrollY={this.scrollY}
           />
         </ScrollView>
 

--- a/app/components/ProposedIndicator/ProposedIndicatorMain.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorMain.js
@@ -87,10 +87,11 @@ class ProposedIndicatorContent extends Component {
             {this.renderAddNewBtn()}
             <ListUser
               scorecardUuid={this.props.scorecardUuid}
-              numberOfProposedParticipant={Participant.getNumberOfProposedParticipant(this.props.scorecardUuid)}
+              numberOfProposedParticipant={Participant.getProposedParticipants(this.props.scorecardUuid).length}
               participantModalRef={this.props.participantModalRef}
               formModalRef={this.props.formModalRef}
               updateModalVisible={(status) => this.props.updateModalVisible(status)}
+              scrollY={this.scrollY}
             />
           </ScrollView>
 

--- a/app/components/ProposedIndicator/ProposedIndicatorNavHeader.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorNavHeader.js
@@ -1,29 +1,25 @@
 import React from 'react';
 import { Animated, View, Text } from 'react-native';
-import { Header, Left, Right, Title } from "native-base";
+import { Header, Left, Right } from "native-base";
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import { HeaderBackButton } from '@react-navigation/stack';
+import IonIcon from 'react-native-vector-icons/Ionicons'
 
 import {LocalizationContext} from '../Translations';
-import ProgressHeader from '../Share/ProgressHeader';
 import HeaderIconButton from '../Share/HeaderIconButton';
 import CustomAlertMessage from '../Share/CustomAlertMessage';
 import NavigationHeaderBody from '../NavigationHeaderBody';
 import ProgressStep from '../ProgressStep';
 import Color from '../../themes/color';
 import { navigateBack, navigateHome } from '../../utils/navigation_util';
-import { getDeviceStyle, navigationBackButtonFlex, navigationTitlePaddingLeft } from '../../utils/responsive_util';
-import { FontFamily } from '../../assets/stylesheets/theme/font';
-import { navigationHeaderTitleFontSize } from '../../utils/font_size_util';
+import { getDeviceStyle, navigationBackButtonFlex } from '../../utils/responsive_util';
 
-// const headerWithAudioMaxHeight = getDeviceStyle(265, 230);
-const headerMaxHeight = getDeviceStyle(156, 230);
-const headerMinHeight = 64;
+const headerMaxHeight = getDeviceStyle(156, 156);
+const headerMinHeight = 56;
 const headerScrollDistance = (headerMaxHeight - headerMinHeight);
 
 const ProposedIndicatorNavHeader = (props) => {
-  // const contextType = LocalizationContext;
-  // const {translations} = context;
+  const {translations} = React.useContext(LocalizationContext);
   const [visibleModal, setVisibleModal] = React.useState(false)
 
   const headerHeight = props.scrollY.interpolate({
@@ -38,46 +34,58 @@ const ProposedIndicatorNavHeader = (props) => {
     extrapolate: 'extend'
   });
 
+  const tipIconOpacity = props.scrollY.interpolate({
+    inputRange: [0, headerMaxHeight, headerMaxHeight + 30],
+    outputRange: [0, 0, 1],
+    extrapolate: 'clamp',
+  })
+
+  const goToHomeScreen = () => {
+    setVisibleModal(false)
+    navigateHome();
+  }
+
   const renderProgressStep = () => {
     return <Animated.View style={{marginTop: getDeviceStyle(10, 4), alignSelf: 'center', opacity: progressOpacity}}>
              <ProgressStep progressIndex={3} steps={!!props.steps && props.steps}/>
            </Animated.View>
   }
 
+  const renderTipIcon = () => {
+    return <Animated.View style={{opacity: tipIconOpacity, marginRight: 4}} >
+              <HeaderIconButton onPress={() => props.showTipModal()}>
+                <IonIcon name="bulb-outline" size={getDeviceStyle(24, wp('5.5%'))} color={Color.whiteColor} />
+              </HeaderIconButton>
+           </Animated.View>
+  }
+
   return (
-    <Animated.View style={{position: 'absolute', top: 0, zIndex: 1, backgroundColor: 'green', height: headerHeight, width: '100%'}}>
-      <View style={{borderWidth: 1, flexGrow: 1}}>
-        <View style={{flexDirection: 'row', alignItems: 'center', marginTop: 6}}>
-          <Left style={{flex: navigationBackButtonFlex}}>
-            <HeaderBackButton tintColor={Color.whiteColor} onPress={() => navigateBack()} style={{ marginLeft: 0 }} />
-          </Left>
-
-          <NavigationHeaderBody title={'ការបំផុសលក្ខណៈវិនិច្ឆ័យ'} />
-          {/* <Title style={{fontSize: navigationHeaderTitleFontSize(), fontFamily: FontFamily.title, textTransform: 'capitalize'}}>
-            ការបំផុសលក្ខណៈវិនិច្ឆ័យ
-          </Title> */}
-
-          {/* <Right style={{maxWidth: wp('14%'), marginRight: getDeviceStyle(-19, -6)}}> */}
-          <Right style={{maxWidth: wp('14%'), borderWidth: 1, marginRight: 0}}>
-            <HeaderIconButton onPress={() => setVisibleModal(true)} icon='home' />
-          </Right>
+    <Animated.View style={{position: 'absolute', top: 0, zIndex: 1, backgroundColor: Color.headerColor, height: headerHeight, width: '100%', elevation: 3}}>
+      <Header backgroundColor={Color.headerColor} style={{elevation: 0}}>
+        <View style={{borderWidth: 0, flexGrow: 1}}>
+          <View style={{flexDirection: 'row', alignItems: 'center', marginTop: 6}}>
+            <Left style={{flex: navigationBackButtonFlex, marginRight: getDeviceStyle(0, 10)}}>
+              <HeaderBackButton tintColor={Color.whiteColor} onPress={() => navigateBack()} style={{ marginLeft: getDeviceStyle(0, 10) }} />
+            </Left>
+            <NavigationHeaderBody title={translations.proposeTheIndicator} />
+            <Right style={{maxWidth: wp('14%'), marginRight: getDeviceStyle(-19, 6)}}>
+              {renderTipIcon()}
+              <HeaderIconButton onPress={() => setVisibleModal(true)} icon='home'/>
+            </Right>
+          </View>
+          {renderProgressStep()}
         </View>
-        {/* {renderProgressStep()} */}
-      </View>
+      </Header>
       <CustomAlertMessage
         visible={visibleModal}
-        // title={translations.returnToHomeScreen}
-        // description={translations.doYouWantToReturnToHomeScreen}
-        // closeButtonLabel={translations.close}
-        title={'Return home?'}
-        description={'Do you really want to return home?'}
-        closeButtonLabel={'Close'}
+        title={translations.returnToHomeScreen}
+        description={translations.doYouWantToReturnToHomeScreen}
+        closeButtonLabel={translations.close}
         hasConfirmButton={true}
-        // confirmButtonLabel={translations.ok}
-        confirmButtonLabel={'Ok'}
+        confirmButtonLabel={translations.ok}
         isConfirmButtonDisabled={false}
         onDismiss={() => setVisibleModal(false)}
-        onConfirm={() => {}}
+        onConfirm={() => goToHomeScreen()}
       />
     </Animated.View>
   )

--- a/app/components/ProposedIndicator/ProposedIndicatorNavHeader.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorNavHeader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Animated, View, Text } from 'react-native';
+import { Animated, View } from 'react-native';
 import { Header, Left, Right } from "native-base";
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import { HeaderBackButton } from '@react-navigation/stack';
@@ -14,7 +14,7 @@ import Color from '../../themes/color';
 import { navigateBack, navigateHome } from '../../utils/navigation_util';
 import { getDeviceStyle, navigationBackButtonFlex } from '../../utils/responsive_util';
 
-const headerMaxHeight = getDeviceStyle(156, 156);
+const headerMaxHeight = 156;
 const headerMinHeight = 56;
 const headerScrollDistance = (headerMaxHeight - headerMinHeight);
 
@@ -35,8 +35,8 @@ const ProposedIndicatorNavHeader = (props) => {
   });
 
   const tipIconOpacity = props.scrollY.interpolate({
-    inputRange: [0, headerMaxHeight, headerMaxHeight + 30],
-    outputRange: [0, 0, 1],
+    inputRange: [0, headerMaxHeight],
+    outputRange: [0, 1],
     extrapolate: 'clamp',
   })
 
@@ -59,23 +59,27 @@ const ProposedIndicatorNavHeader = (props) => {
            </Animated.View>
   }
 
+  const renderHeader = () => {
+    return <Header backgroundColor={Color.headerColor} style={{elevation: 0}}>
+            <View style={{flexGrow: 1}}>
+              <View style={{flexDirection: 'row', alignItems: 'center', marginTop: 6}}>
+                <Left style={{flex: navigationBackButtonFlex, marginRight: getDeviceStyle(0, 10)}}>
+                  <HeaderBackButton tintColor={Color.whiteColor} onPress={() => navigateBack()} style={{ marginLeft: getDeviceStyle(0, 10) }} />
+                </Left>
+                <NavigationHeaderBody title={translations.proposeTheIndicator} />
+                <Right style={{maxWidth: wp('14%'), marginRight: getDeviceStyle(-19, 6)}}>
+                  {renderTipIcon()}
+                  <HeaderIconButton onPress={() => setVisibleModal(true)} icon='home'/>
+                </Right>
+              </View>
+              {renderProgressStep()}
+            </View>
+          </Header>
+  }
+
   return (
     <Animated.View style={{position: 'absolute', top: 0, zIndex: 1, backgroundColor: Color.headerColor, height: headerHeight, width: '100%', elevation: 3}}>
-      <Header backgroundColor={Color.headerColor} style={{elevation: 0}}>
-        <View style={{borderWidth: 0, flexGrow: 1}}>
-          <View style={{flexDirection: 'row', alignItems: 'center', marginTop: 6}}>
-            <Left style={{flex: navigationBackButtonFlex, marginRight: getDeviceStyle(0, 10)}}>
-              <HeaderBackButton tintColor={Color.whiteColor} onPress={() => navigateBack()} style={{ marginLeft: getDeviceStyle(0, 10) }} />
-            </Left>
-            <NavigationHeaderBody title={translations.proposeTheIndicator} />
-            <Right style={{maxWidth: wp('14%'), marginRight: getDeviceStyle(-19, 6)}}>
-              {renderTipIcon()}
-              <HeaderIconButton onPress={() => setVisibleModal(true)} icon='home'/>
-            </Right>
-          </View>
-          {renderProgressStep()}
-        </View>
-      </Header>
+      {renderHeader()}
       <CustomAlertMessage
         visible={visibleModal}
         title={translations.returnToHomeScreen}

--- a/app/components/ProposedIndicator/ProposedIndicatorNavHeader.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorNavHeader.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Animated, View, Text } from 'react-native';
+import { Header, Left, Right, Title } from "native-base";
+import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
+import { HeaderBackButton } from '@react-navigation/stack';
+
+import {LocalizationContext} from '../Translations';
+import ProgressHeader from '../Share/ProgressHeader';
+import HeaderIconButton from '../Share/HeaderIconButton';
+import CustomAlertMessage from '../Share/CustomAlertMessage';
+import NavigationHeaderBody from '../NavigationHeaderBody';
+import ProgressStep from '../ProgressStep';
+import Color from '../../themes/color';
+import { navigateBack, navigateHome } from '../../utils/navigation_util';
+import { getDeviceStyle, navigationBackButtonFlex, navigationTitlePaddingLeft } from '../../utils/responsive_util';
+import { FontFamily } from '../../assets/stylesheets/theme/font';
+import { navigationHeaderTitleFontSize } from '../../utils/font_size_util';
+
+// const headerWithAudioMaxHeight = getDeviceStyle(265, 230);
+const headerMaxHeight = getDeviceStyle(156, 230);
+const headerMinHeight = 64;
+const headerScrollDistance = (headerMaxHeight - headerMinHeight);
+
+const ProposedIndicatorNavHeader = (props) => {
+  // const contextType = LocalizationContext;
+  // const {translations} = context;
+  const [visibleModal, setVisibleModal] = React.useState(false)
+
+  const headerHeight = props.scrollY.interpolate({
+    inputRange: [0, headerScrollDistance],
+    outputRange: [headerMaxHeight, headerMinHeight],
+    extrapolate: 'clamp',
+  });
+
+  const progressOpacity = props.scrollY.interpolate({
+    inputRange: [0, headerScrollDistance],
+    outputRange: [1, 0],
+    extrapolate: 'extend'
+  });
+
+  const renderProgressStep = () => {
+    return <Animated.View style={{marginTop: getDeviceStyle(10, 4), alignSelf: 'center', opacity: progressOpacity}}>
+             <ProgressStep progressIndex={3} steps={!!props.steps && props.steps}/>
+           </Animated.View>
+  }
+
+  return (
+    <Animated.View style={{position: 'absolute', top: 0, zIndex: 1, backgroundColor: 'green', height: headerHeight, width: '100%'}}>
+      <View style={{borderWidth: 1, flexGrow: 1}}>
+        <View style={{flexDirection: 'row', alignItems: 'center', marginTop: 6}}>
+          <Left style={{flex: navigationBackButtonFlex}}>
+            <HeaderBackButton tintColor={Color.whiteColor} onPress={() => navigateBack()} style={{ marginLeft: 0 }} />
+          </Left>
+
+          <NavigationHeaderBody title={'ការបំផុសលក្ខណៈវិនិច្ឆ័យ'} />
+          {/* <Title style={{fontSize: navigationHeaderTitleFontSize(), fontFamily: FontFamily.title, textTransform: 'capitalize'}}>
+            ការបំផុសលក្ខណៈវិនិច្ឆ័យ
+          </Title> */}
+
+          {/* <Right style={{maxWidth: wp('14%'), marginRight: getDeviceStyle(-19, -6)}}> */}
+          <Right style={{maxWidth: wp('14%'), borderWidth: 1, marginRight: 0}}>
+            <HeaderIconButton onPress={() => setVisibleModal(true)} icon='home' />
+          </Right>
+        </View>
+        {/* {renderProgressStep()} */}
+      </View>
+      <CustomAlertMessage
+        visible={visibleModal}
+        // title={translations.returnToHomeScreen}
+        // description={translations.doYouWantToReturnToHomeScreen}
+        // closeButtonLabel={translations.close}
+        title={'Return home?'}
+        description={'Do you really want to return home?'}
+        closeButtonLabel={'Close'}
+        hasConfirmButton={true}
+        // confirmButtonLabel={translations.ok}
+        confirmButtonLabel={'Ok'}
+        isConfirmButtonDisabled={false}
+        onDismiss={() => setVisibleModal(false)}
+        onConfirm={() => {}}
+      />
+    </Animated.View>
+  )
+}
+
+export default ProposedIndicatorNavHeader

--- a/app/components/ProposedIndicator/ProposedIndicatorNavHeader.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorNavHeader.js
@@ -78,7 +78,7 @@ const ProposedIndicatorNavHeader = (props) => {
   }
 
   return (
-    <Animated.View style={{position: 'absolute', top: 0, zIndex: 1, backgroundColor: Color.headerColor, height: headerHeight, width: '100%', elevation: 3}}>
+    <Animated.View style={{position: 'absolute', top: 0, backgroundColor: Color.headerColor, height: headerHeight, width: '100%'}}>
       {renderHeader()}
       <CustomAlertMessage
         visible={visibleModal}

--- a/app/components/ProposedIndicator/ProposedIndicatorNewProposeButton.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorNewProposeButton.js
@@ -20,28 +20,37 @@ class ProposedIndicatorNewProposeButton extends Component {
     this.props.participantModalRef.current?.dismiss();
   }
 
+  renderAnonymous() {
+    const anonymous = Participant.getAnonymousByScorecard(this.props.scorecardUuid).length;
+    if (anonymous > 0)
+      return ` (${this.context.translations.anonymous} ${anonymous})`;
+  }
+
   render() {
     const {translations} = this.context;
-    const raisedParticipants = Participant.getRaisedParticipants(this.props.scorecardUuid);
+    const raisedParticipants = Participant.getProposedParticipants(this.props.scorecardUuid);
     return (
       <View style={styles.addNewButtonContainer}>
-        <Text style={styles.headingTitle}>
-          { translations.numberOfParticipant }: { Participant.getAll(this.props.scorecardUuid).length } {translations.pax}
+        <Text style={[styles.headingTitle, {flex: 1}]}>
+          { translations.numberOfParticipant }: { Participant.getAllByScorecard(this.props.scorecardUuid).length } {translations.pax}
+          {this.renderAnonymous()}
         </Text>
 
-        <View style={{flexGrow: 1, alignItems: 'flex-end'}}>
-          <ParticipantInfo
-            title={translations.proposeTheIndicator}
-            participants={Participant.getNotRaised(this.props.scorecardUuid)}
-            scorecardUuid={ this.props.scorecardUuid }
-            buttonVisible={raisedParticipants.length > 0}
-            mode={{type: 'button', label: translations.proposeNewIndicator, iconName: 'plus'}}
-            selectParticipant={(participant) => navigate('CreateNewIndicator', {scorecard_uuid: this.props.scorecardUuid, participant_uuid: participant.uuid})}
-            closeModal={() => this.closeModal()}
-            participantModalRef={this.props.participantModalRef}
-            formModalRef={this.props.formModalRef}
-          />
-        </View>
+        { raisedParticipants.length > 0 &&
+          <View style={{flex: 1, alignItems: 'flex-end'}}>
+            <ParticipantInfo
+              title={translations.proposeTheIndicator}
+              participants={Participant.getNotRaised(this.props.scorecardUuid)}
+              scorecardUuid={ this.props.scorecardUuid }
+              buttonVisible={raisedParticipants.length > 0}
+              mode={{type: 'button', label: translations.proposeNewIndicator, iconName: 'plus'}}
+              selectParticipant={(participant) => navigate('CreateNewIndicator', {scorecard_uuid: this.props.scorecardUuid, participant_uuid: participant.uuid})}
+              closeModal={() => this.closeModal()}
+              participantModalRef={this.props.participantModalRef}
+              formModalRef={this.props.formModalRef}
+            />
+          </View>
+        }
       </View>
     )
   }

--- a/app/components/ProposedIndicator/ProposedIndicatorNewProposeButton.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorNewProposeButton.js
@@ -1,0 +1,50 @@
+import React, {Component} from 'react';
+import {View} from 'react-native';
+import {Text} from 'native-base';
+
+import {LocalizationContext} from '../Translations';
+import ParticipantInfo from '../CreateNewIndicator/ParticipantInfo';
+import Participant from '../../models/Participant';
+import { navigate } from '../../navigators/app_navigator';
+import { getDeviceStyle } from '../../utils/responsive_util';
+import ProposedIndicatorTabletStyles from '../../styles/tablet/ProposedIndicatorComponentStyle';
+import ProposedIndicatorMobileStyles from '../../styles/mobile/ProposedIndicatorComponentStyle';
+
+const styles = getDeviceStyle(ProposedIndicatorTabletStyles, ProposedIndicatorMobileStyles);
+
+class ProposedIndicatorNewProposeButton extends Component {
+  static contextType = LocalizationContext;
+
+  closeModal() {
+    this.props.updateModalVisible(false)
+    this.props.participantModalRef.current?.dismiss();
+  }
+
+  render() {
+    const {translations} = this.context;
+    const raisedParticipants = Participant.getRaisedParticipants(this.props.scorecardUuid);
+    return (
+      <View style={styles.addNewButtonContainer}>
+        <Text style={styles.headingTitle}>
+          { translations.numberOfParticipant }: { Participant.getAll(this.props.scorecardUuid).length } {translations.pax}
+        </Text>
+
+        <View style={{flexGrow: 1, alignItems: 'flex-end'}}>
+          <ParticipantInfo
+            title={translations.proposeTheIndicator}
+            participants={Participant.getNotRaised(this.props.scorecardUuid)}
+            scorecardUuid={ this.props.scorecardUuid }
+            buttonVisible={raisedParticipants.length > 0}
+            mode={{type: 'button', label: translations.proposeNewIndicator, iconName: 'plus'}}
+            selectParticipant={(participant) => navigate('CreateNewIndicator', {scorecard_uuid: this.props.scorecardUuid, participant_uuid: participant.uuid})}
+            closeModal={() => this.closeModal()}
+            participantModalRef={this.props.participantModalRef}
+            formModalRef={this.props.formModalRef}
+          />
+        </View>
+      </View>
+    )
+  }
+}
+
+export default ProposedIndicatorNewProposeButton

--- a/app/components/Share/HeaderIconButton.js
+++ b/app/components/Share/HeaderIconButton.js
@@ -9,8 +9,10 @@ class HeaderIconButton extends Component {
     const mobileIconSize = this.props.mobileIconSize || wp('5.5%');
 
     return (
-      <Button transparent onPress={() => this.props.onPress()}>
-        <Icon name={this.props.icon} style={{fontSize: getDeviceStyle(24, mobileIconSize), marginTop: -2, marginRight: getDeviceStyle(16, 0)}} />
+      <Button transparent onPress={() => !!this.props.onPress && this.props.onPress()}>
+        { !!this.props.children ? this.props.children
+          : <Icon name={this.props.icon} style={[{fontSize: getDeviceStyle(24, mobileIconSize), marginTop: -2, marginRight: getDeviceStyle(16, 0)}, this.props.iconStyle]} />
+        }
       </Button>
     )
   }

--- a/app/screens/ProposedIndicator/ProposedIndicator.js
+++ b/app/screens/ProposedIndicator/ProposedIndicator.js
@@ -3,7 +3,6 @@ import { View, BackHandler } from 'react-native';
 
 import {LocalizationContext} from '../../components/Translations';
 import ProposedIndicatorMain from '../../components/ProposedIndicator/ProposedIndicatorMain';
-import ProgressHeader from '../../components/Share/ProgressHeader';
 import TipModal from '../../components/Tip/TipModal';
 import FormBottomSheetModal from '../../components/FormBottomSheetModal/FormBottomSheetModal';
 
@@ -57,8 +56,6 @@ class ProposedIndicator extends Component {
     return (
       <React.Fragment>
         <View style={{flex: 1}}>
-          <ProgressHeader title={translations['getStarted']} progressIndex={3} />
-
           <ProposedIndicatorMain
             scorecardUuid={scorecard_uuid}
             visibleModal={this.state.visibleModal}

--- a/app/screens/ProposedIndicator/ProposedIndicator.js
+++ b/app/screens/ProposedIndicator/ProposedIndicator.js
@@ -1,7 +1,6 @@
 import React, {Component} from 'react';
 import { View, BackHandler } from 'react-native';
 
-import {LocalizationContext} from '../../components/Translations';
 import ProposedIndicatorMain from '../../components/ProposedIndicator/ProposedIndicatorMain';
 import TipModal from '../../components/Tip/TipModal';
 import FormBottomSheetModal from '../../components/FormBottomSheetModal/FormBottomSheetModal';
@@ -12,8 +11,6 @@ import Scorecard from '../../models/Scorecard';
 import { tipModalSnapPoints, PROPOSED_INDICATOR, participantModalSnapPoints } from '../../constants/modal_constant';
 
 class ProposedIndicator extends Component {
-  static contextType = LocalizationContext;
-
   constructor(props) {
     super(props);
     this.state = {
@@ -49,28 +46,24 @@ class ProposedIndicator extends Component {
   }
 
   render() {
-    const {translations} = this.context;
     const { scorecard_uuid } = this.props.route.params;
     const tipSecondSnapPoint = tipModalSnapPoints[PROPOSED_INDICATOR];
 
     return (
-      <React.Fragment>
-        <View style={{flex: 1}}>
-          <ProposedIndicatorMain
-            scorecardUuid={scorecard_uuid}
-            visibleModal={this.state.visibleModal}
-            tipModalRef={this.tipModalRef}
-            participantModalRef={this.participantModalRef}
-            formModalRef={this.formModalRef}
-            updateModalVisible={(status) => this.setState({ visibleModal: status })}
-          />
-        </View>
-
+      <View style={{flexGrow: 1}}>
+        <ProposedIndicatorMain
+          scorecardUuid={scorecard_uuid}
+          visibleModal={this.state.visibleModal}
+          tipModalRef={this.tipModalRef}
+          participantModalRef={this.participantModalRef}
+          formModalRef={this.formModalRef}
+          updateModalVisible={(status) => this.setState({ visibleModal: status })}
+        />
         <TipModal tipModalRef={this.tipModalRef} snapPoints={tipSecondSnapPoint} screenName='ProposedIndicator' />
         <FormBottomSheetModal ref={this.formModalRef} formModalRef={this.participantModalRef} snapPoints={participantModalSnapPoints}
           onDismissModal={() => this.onDismissBottomSheet()}
         />
-      </React.Fragment>
+      </View>
     );
   }
 }

--- a/app/styles/mobile/ProposedIndicatorComponentStyle.js
+++ b/app/styles/mobile/ProposedIndicatorComponentStyle.js
@@ -1,11 +1,20 @@
 import { StyleSheet } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
-
 import { titleFontSize } from '../../utils/font_size_util';
+import { FontFamily } from '../../assets/stylesheets/theme/font';
+import Color from '../../themes/color';
 
 const ProposedIndicatorComponentStyles = StyleSheet.create({
+  addNewButtonContainer: {
+    alignItems: 'center',
+    backgroundColor: Color.defaultBgColor,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    paddingBottom: 14,
+  },
   headingTitle: {
     fontSize: titleFontSize(),
+    fontFamily: FontFamily.title
   },
   noDataContainer: {
     marginTop: -wp('45%')

--- a/app/styles/tablet/ProposedIndicatorComponentStyle.js
+++ b/app/styles/tablet/ProposedIndicatorComponentStyle.js
@@ -1,10 +1,20 @@
 import { StyleSheet } from 'react-native';
 import {widthPercentageToDP as wp} from 'react-native-responsive-screen';
 import { titleFontSize } from '../../utils/font_size_util';
+import { FontFamily } from '../../assets/stylesheets/theme/font';
+import Color from '../../themes/color';
 
 const ProposedIndicatorComponentStyles = StyleSheet.create({
+  addNewButtonContainer: {
+    alignItems: 'center',
+    backgroundColor: Color.defaultBgColor,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    paddingBottom: 14,
+  },
   headingTitle: {
-    fontSize: titleFontSize()
+    fontSize: titleFontSize(),
+    fontFamily: FontFamily.title
   },
   noDataContainer: {
     marginTop: -wp('30%')

--- a/app/themes/color.js
+++ b/app/themes/color.js
@@ -33,6 +33,7 @@ const Color = {
   lightGreenColor: '#52c72c',
   accordionContentBgColor: '#fbf9ed',
   orangeColor: '#ffa500',
+  defaultBgColor: '#f0f0f0',
 };
 
 export default Color;


### PR DESCRIPTION
This pull request makes some enhancements to the proposed indicator as follows: 
- Shrink the navigation header by hiding the progress step when the user scrolls the content
- Show the tip icon on the navigation header when the header starts to shrink
- Make the add new propose indicator button stick to the top when the user scrolls the content

** Notice:
- The new UI of the tip with outlined style will be updated on another PR

Below are the screenshots of the shrunk navigation header on mobile and tablet devices:
[proposed indicator header.zip](https://github.com/ilabsea/scorecard_mobile/files/10989617/proposed.indicator.header.zip)
