### PR TITLE
Make indicator card flexible height

### DIFF
--- a/app/components/IndicatorDevelopment/ProposedIndicatorItem.js
+++ b/app/components/IndicatorDevelopment/ProposedIndicatorItem.js
@@ -6,6 +6,7 @@ import indicatorHelper from '../../helpers/indicator_helper';
 import indicatorDevelopmentHelper from '../../helpers/indicator_development_helper';
 import Color from '../../themes/color';
 import Scorecard from '../../models/Scorecard';
+import {getDeviceStyle} from '../../utils/responsive_util';
 
 class ProposedIndicatorItem extends Component {
   static contextType = LocalizationContext;
@@ -41,6 +42,8 @@ class ProposedIndicatorItem extends Component {
             updatePlayingUuid={(uuid) => this.props.updatePlayingUuid(uuid)}
             containerStyle={{borderColor: getBorderColor, borderWidth: getBorderWidth}}
             onPressItem={ () => this.handleSelected() }
+            titleStyle={{marginTop: getDeviceStyle(18, 13)}}
+            subtitleStyle={{marginBottom: 6}}
           />
   }
 }

--- a/app/components/IndicatorDevelopment/SelectedIndicatorItem.js
+++ b/app/components/IndicatorDevelopment/SelectedIndicatorItem.js
@@ -15,6 +15,7 @@ import indicatorHelper from '../../helpers/indicator_helper';
 import indicatorDevelopmentHelper from '../../helpers/indicator_development_helper';
 import Scorecard from '../../models/Scorecard';
 import {bodyFontSize} from '../../utils/font_size_util';
+import {getDeviceStyle} from '../../utils/responsive_util';
 
 class SelectedIndicatorItem extends Component {
   static contextType = LocalizationContext;
@@ -59,7 +60,7 @@ class SelectedIndicatorItem extends Component {
   }
 
   renderCardTitle = () => {
-    return <View style={{flexDirection: 'row', marginLeft: -14, marginTop: 6}}>
+    return <View style={{flexDirection: 'row', marginLeft: -14, marginTop: getDeviceStyle(18, 16)}}>
               <Icon name="more-vert" style={{color: Color.lightGrayColor, fontSize: 20, textAlign: 'center', marginTop: 3}} />
               <Text numberOfLines={2} style={{fontSize: bodyFontSize(), marginRight: 18}}>
                 {this.props.order + 1}. {this.state.indicator.content}
@@ -72,7 +73,7 @@ class SelectedIndicatorItem extends Component {
             itemUuid={this.state.indicator.indicator_uuid}
             customTitle={this.renderCardTitle()}
             subtitle={indicatorDevelopmentHelper.getCardSubtitle(this.props.indicator, this.context.translations)}
-            subtitleStyle={{marginLeft: 6}}
+            subtitleStyle={{marginLeft: 6, marginBottom: getDeviceStyle(8, 6)}}
             audio={this.state.indicator.local_audio}
             playingUuid={this.props.playingUuid}
             updatePlayingUuid={(uuid) => this.props.updatePlayingUuid(uuid)}
@@ -82,7 +83,7 @@ class SelectedIndicatorItem extends Component {
   }
 
   renderDeleteButton()  {
-    return <SwipeLeftButton label={this.context.translations.delete} customStyle={{height: 116, marginTop: 26, width: 90}} onPress={() =>  this.handleRemoveIndicator()} />
+    return <SwipeLeftButton label={this.context.translations.delete} customStyle={{marginTop: 26, marginBottom: 10, width: 90}} onPress={() =>  this.handleRemoveIndicator()} />
   }
 
   render() {

--- a/app/components/ProposeNewIndicator/ProposeNewIndicatorCardItem.js
+++ b/app/components/ProposeNewIndicator/ProposeNewIndicatorCardItem.js
@@ -62,12 +62,19 @@ class ProposeNewIndicatorCardItem extends React.Component {
     return languageIndicator != undefined ? languageIndicator.local_audio : null
   }
 
+  renderTitle() {
+    return <TextHighlight textToHighlight={this.getIndicatorName()} searchWords={[this.props.searchedText]} fontSize={bodyFontSize()} fontFamily={FontFamily.body} numberOfLines={2}
+              containerStyle={proposedIndicatorStyleHelper.getCardTitleStyles(this.props.isIndicatorBase)}
+           />
+  }
+
   renderCard() {
     return <CustomAudioCard
             isOutlined={true}
             itemUuid={this.props.indicatorUuid}
-            customTitle={<TextHighlight textToHighlight={this.getIndicatorName()} searchWords={[this.props.searchedText]} fontSize={bodyFontSize()} fontFamily={FontFamily.body} numberOfLines={2} containerStyle={{marginTop: this.props.isIndicatorBase ? 10 : 6}} />}
+            customTitle={this.renderTitle()}
             subtitle={this.props.isIndicatorBase && proposedIndicatorHelper.getCardSubtitle(this.context.translations, this.props.scorecardUuid, this.props.indicatorableId)}
+            subtitleStyle={{marginBottom: 6}}
             audio={this.getAudio()}
             playingUuid={this.props.playingUuid}
             updatePlayingUuid={(uuid) => this.props.updatePlayingUuid(uuid)}

--- a/app/components/ProposeNewIndicator/ProposeNewIndicatorSearchResultCardList.js
+++ b/app/components/ProposeNewIndicator/ProposeNewIndicatorSearchResultCardList.js
@@ -15,6 +15,7 @@ class ProposeNewIndicatorSearchResultCardList extends React.Component {
 
       return <ProposeNewIndicatorCardItem key={indicator.uuid} scorecardUuid={this.props.scorecardUuid} audio={null} searchedText={this.props.searchedText}
                 indicatorName={indicator.name} indicatorableId={indicator.indicatorable_id} indicatorType={indicator.type} indicatorUuid={indicator.indicator_uuid}
+                isIndicatorBase={this.props.isIndicatorBase}
                 containerStyle={proposedStyle}
                 onPressItem={() => this.props.onPressItem(indicator)}
                 isSwipeable={false}

--- a/app/components/Share/CustomAudioCard.js
+++ b/app/components/Share/CustomAudioCard.js
@@ -30,6 +30,7 @@ class CustomAudioCard extends React.Component {
         onPress={() => !!this.props.onPressItem && this.props.onPressItem()}
         onLongPress={() => !!this.props.onLongPress && this.props.onLongPress()}
         hideAudioPlayer={true}
+        allowFlexibleHeight={true}
       >
         <CustomAudioPlayerButton
           audio={this.props.audio}
@@ -51,7 +52,7 @@ const customStyles = StyleSheet.create({
   container: {
     marginBottom: 10, 
     marginTop: 26,
-    height: 116,
+    // height: 116,
     width: '100%',
   },
   outlined: {

--- a/app/components/Share/CustomAudioCard.js
+++ b/app/components/Share/CustomAudioCard.js
@@ -14,7 +14,7 @@ const styles = getDeviceStyle(cardItemTabletStyles, cardItemMobileStyles);
 class CustomAudioCard extends React.Component {
   renderCardLabel = () => {
     return <View style={styles.indicatorOutlinedLabelContainer}>
-              { !!this.props.customTitle ? this.props.customTitle : <Text numberOfLines={2} style={{fontSize: bodyFontSize(), marginTop: 10}}>{this.props.title}</Text> }
+              { !!this.props.customTitle ? this.props.customTitle : <Text numberOfLines={2} style={[{fontSize: bodyFontSize(), marginTop: 10}, this.props.titleStyle]}>{this.props.title}</Text> }
               { this.props.subtitle && <Text style={[styles.subLabel, {color: Color.lightGrayColor}, this.props.subtitleStyle]}>{this.props.subtitle}</Text> }
            </View>
   }
@@ -52,7 +52,6 @@ const customStyles = StyleSheet.create({
   container: {
     marginBottom: 10, 
     marginTop: 26,
-    // height: 116,
     width: '100%',
   },
   outlined: {

--- a/app/helpers/proposed_indicator_style_helper.js
+++ b/app/helpers/proposed_indicator_style_helper.js
@@ -11,6 +11,7 @@ const proposedIndicatorStyleHelper = (() => {
     getAddNewProposeButtonStyles,
     getSearchBoxMarginTop,
     getSearchResultTopPosition,
+    getCardTitleStyles,
   }
 
   function getStyleByProposeType(isIndicatorBase, type) {
@@ -55,6 +56,10 @@ const proposedIndicatorStyleHelper = (() => {
       return _calculateSearchResultPosition(searchContainerHeight, instructionHeight, isShortScreenDevice() ? [75, 117] : [74, 114])
 
     return _calculateSearchResultPosition(searchContainerHeight, instructionHeight, isShortScreenDevice() ? [146, 185] : [144, 183])
+  }
+
+  function getCardTitleStyles(isIndicatorBase) {
+    return { marginTop: getDeviceStyle(18, 14), marginBottom: isIndicatorBase ? 0 : getDeviceStyle(10, 6) }
   }
 
   // private method

--- a/app/styles/mobile/ProposedIndicatorCardComponentStyle.js
+++ b/app/styles/mobile/ProposedIndicatorCardComponentStyle.js
@@ -29,31 +29,26 @@ const ProposedIndicatorCardComponentStyles = StyleSheet.create({
   },
   indicatorBaseOutlinedCardContainer: {
     marginBottom: 0,
-    marginTop: 40,
-    height: 116,
+    marginTop: 35,
     width: '100%',
     borderWidth: 1,
     borderColor: Color.lightGrayColor,
     elevation: 0
   },
   indicatorBaseSwipeableButton: {
-    height: 115,
-    marginTop: 40,
+    marginTop: 35,
     width: 70,
   },
   participantBaseOutlinedCardContainer: {
     marginBottom: 0,
-    marginTop: 40,
-    minHeight: 90,
-    height: 102,
+    marginTop: 35,
     width: '100%',
     borderWidth: 1,
     borderColor: Color.lightGrayColor,
     elevation: 0
   },
   participantBaseSwipeableButton: {
-    height: 102,
-    marginTop: 40,
+    marginTop: 35,
     width: 90,
   },
   indicatorOutlinedLabelContainer: {

--- a/app/styles/tablet/ProposedIndicatorCardComponentStyle.js
+++ b/app/styles/tablet/ProposedIndicatorCardComponentStyle.js
@@ -23,31 +23,27 @@ const ProposedIndicatorCardComponentStyles = StyleSheet.create({
     paddingHorizontal: 14
   },
   indicatorBaseOutlinedCardContainer: {
-    marginBottom: 0,
+    marginBottom: 1,
     marginTop: 35,
-    height: 118,
     width: '100%',
     borderWidth: 1,
     borderColor: Color.lightGrayColor,
-    elevation: 0
+    elevation: 0,
   },
   indicatorBaseSwipeableButton: {
-    height: 118,
-    marginTop: 40,
+    marginTop: 35,
     width: 90
   },
   participantBaseOutlinedCardContainer: {
-    marginBottom: 0,
+    marginBottom: 1,
     marginTop: 35,
-    height: 95,
     width: '100%',
     borderWidth: 1,
     borderColor: Color.lightGrayColor,
-    elevation: 0
+    elevation: 0,
   },
   participantBaseSwipeableButton: {
-    height: 95,
-    marginTop: 40,
+    marginTop: 35,
     width: 90
   },
   indicatorOutlinedLabelContainer: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "prop-types": "^15.7.2",
         "react": "16.13.1",
         "react-native": "0.63.2",
-        "react-native-audio-card-view": "^1.0.7",
+        "react-native-audio-card-view": "^1.0.8",
         "react-native-audio-player-button": "^1.0.7",
         "react-native-copilot": "^2.5.1",
         "react-native-device-info": "^10.3.0",
@@ -13182,9 +13182,9 @@
       }
     },
     "node_modules/react-native-audio-card-view": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/react-native-audio-card-view/-/react-native-audio-card-view-1.0.7.tgz",
-      "integrity": "sha512-WS/a/0MQrzDnoXaVWB4kls+9l+0D9wqt6MV7Ad6H/Lwa7qUNV6F9wl9L3bxQsPDCN3ol55VHHSVCnoVkHaHspw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/react-native-audio-card-view/-/react-native-audio-card-view-1.0.8.tgz",
+      "integrity": "sha512-qR3338/CAzV/4UFLrHZqgkunvJ9t7RrjDbh4jLliNhAIT9WW1AYURTwkjWvVJ4bT2eVjCJO4+oNy+MqhTkdD1w==",
       "engines": {
         "node": ">= 16.0.0"
       },
@@ -27036,9 +27036,9 @@
       }
     },
     "react-native-audio-card-view": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/react-native-audio-card-view/-/react-native-audio-card-view-1.0.7.tgz",
-      "integrity": "sha512-WS/a/0MQrzDnoXaVWB4kls+9l+0D9wqt6MV7Ad6H/Lwa7qUNV6F9wl9L3bxQsPDCN3ol55VHHSVCnoVkHaHspw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/react-native-audio-card-view/-/react-native-audio-card-view-1.0.8.tgz",
+      "integrity": "sha512-qR3338/CAzV/4UFLrHZqgkunvJ9t7RrjDbh4jLliNhAIT9WW1AYURTwkjWvVJ4bT2eVjCJO4+oNy+MqhTkdD1w=="
     },
     "react-native-audio-player-button": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-native": "0.63.2",
-    "react-native-audio-card-view": "^1.0.7",
+    "react-native-audio-card-view": "^1.0.8",
     "react-native-audio-player-button": "^1.0.7",
     "react-native-copilot": "^2.5.1",
     "react-native-device-info": "^10.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7478,10 +7478,10 @@
   dependencies:
     "prop-types" "^15.7.2"
 
-"react-native-audio-card-view@^1.0.7":
-  "integrity" "sha512-WS/a/0MQrzDnoXaVWB4kls+9l+0D9wqt6MV7Ad6H/Lwa7qUNV6F9wl9L3bxQsPDCN3ol55VHHSVCnoVkHaHspw=="
-  "resolved" "https://registry.npmjs.org/react-native-audio-card-view/-/react-native-audio-card-view-1.0.7.tgz"
-  "version" "1.0.7"
+"react-native-audio-card-view@^1.0.8":
+  "integrity" "sha512-qR3338/CAzV/4UFLrHZqgkunvJ9t7RrjDbh4jLliNhAIT9WW1AYURTwkjWvVJ4bT2eVjCJO4+oNy+MqhTkdD1w=="
+  "resolved" "https://registry.npmjs.org/react-native-audio-card-view/-/react-native-audio-card-view-1.0.8.tgz"
+  "version" "1.0.8"
 
 "react-native-audio-player-button@^1.0.7":
   "integrity" "sha512-nDYWod4UotorE6641lTboOiS3Mun6XJEMsgD+nB0LZ1T5mWbexEGLEPYnyHhg9vuwoWtGpkUmPWrGFA1gEqE0g=="


### PR DESCRIPTION
This pull request updates the height of the indicator card (proposed indicator and indicator development screens) to be flexible based on the line of the title of the card.

Below are the screenshots on mobile and tablet devices:
[flexible indicator card.zip](https://github.com/ilabsea/scorecard_mobile/files/11430418/flexible.indicator.card.zip)

