### PR TITLE
Fix the UI of the indicator development when nav header is collapsed

### DIFF
--- a/app/components/IndicatorDevelopment/IndicatorDevelopmentAddNewHeader.js
+++ b/app/components/IndicatorDevelopment/IndicatorDevelopmentAddNewHeader.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
 import Color from '../../themes/color';
-import Tip from '../Share/Tip';
 import OutlinedButton from '../OutlinedButton';
 import { LocalizationContext } from '../Translations';
 import { FontFamily } from '../../assets/stylesheets/theme/font';
@@ -12,7 +11,7 @@ import IndicatorDevelopmentMobileStyles from '../../styles/mobile/IndicatorDevel
 
 const responsiveStyles = getDeviceStyle(IndicatorDevelopmentTabletStyles, IndicatorDevelopmentMobileStyles);
 
-class IndicatorDevelopmentContentHeader extends Component {
+class IndicatorDevelopmentAddNewHeader extends Component {
   static contextType = LocalizationContext;
 
   _renderBtnAddIndicator() {
@@ -31,12 +30,9 @@ class IndicatorDevelopmentContentHeader extends Component {
 
   render() {
     return (
-      <View style={{paddingVertical: containerPadding, paddingBottom: getDeviceStyle(12, 14), backgroundColor: Color.defaultBgColor}}>
-        <Tip screenName='IndicatorDevelopment' showTipModal={() => this.props.tipModalRef.current?.present()} />
-
+      <View style={{paddingBottom: getDeviceStyle(12, 14), paddingTop: getDeviceStyle(4, 0), backgroundColor: Color.defaultBgColor}}>
         <View style={responsiveStyles.titleContainer}>
           <Text style={[styles.h1, responsiveStyles.titleLabel]}>{ this.context.translations.indicatorDevelopment }</Text>
-
           {  this.props.hasData && this._renderBtnAddIndicator() }
         </View>
       </View>
@@ -52,4 +48,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default IndicatorDevelopmentContentHeader;
+export default IndicatorDevelopmentAddNewHeader;

--- a/app/components/IndicatorDevelopment/IndicatorDevelopmentContent.js
+++ b/app/components/IndicatorDevelopment/IndicatorDevelopmentContent.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import { View, Dimensions } from 'react-native';
 
 import { LocalizationContext } from '../Translations';
-import IndicatorDevelopmentContentHeader from './IndicatorDevelopmentContentHeader';
+import IndicatorDevelopmentAddNewHeader from './IndicatorDevelopmentAddNewHeader';
 import IndicatorDevelopmentList from './IndicatorDevelopmentList';
 import EmptyListAction from '../Share/EmptyListAction';
 import Rating from '../../models/Rating';
@@ -43,9 +43,9 @@ class IndicatorDevelopmentContent extends Component {
     );
   }
 
-  renderHeader() {
+  renderAddNewHeader() {
     return (
-      <IndicatorDevelopmentContentHeader
+      <IndicatorDevelopmentAddNewHeader
         openModal={this.props.openModal}
         hasData={!!this.props.selectedIndicators.length}
         hasRating={this.state.hasRating}
@@ -68,7 +68,7 @@ class IndicatorDevelopmentContent extends Component {
             updateSelectedIndicatorsOrder={this.props.updateSelectedIndicatorsOrder}
             hasData={hasData}
             openModal={this.props.openModal}
-            renderHeader={() => this.renderHeader()}
+            renderAddNewHeader={() => this.renderAddNewHeader()}
             headerHeight={this.state.headerHeight}
             hasRating={this.state.hasRating}
             playingUuid={this.props.playingUuid}

--- a/app/components/IndicatorDevelopment/IndicatorDevelopmentList.js
+++ b/app/components/IndicatorDevelopment/IndicatorDevelopmentList.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
-import {Animated, View} from 'react-native';
+import {Animated} from 'react-native';
 import DraggableFlatList from "react-native-draggable-flatlist";
 import AsyncStorage from '@react-native-community/async-storage';
 import SelectedIndicatorItem from './SelectedIndicatorItem';
 import IndicatorDevelopmentInstructionModal from './IndicatorDevelopmentInstructionModal';
 import CollapsibleNavHeader from '../Share/CollapsibleNavHeader';
+import Tip from '../Share/Tip';
 import { LocalizationContext } from '../Translations';
 
 import {headerShrinkOffset} from '../../constants/component_style_constant';
@@ -40,6 +41,8 @@ class IndicatorDevelopmentList extends Component {
 
   renderItem(params) {
     const {item, index, drag, isActive} = params;
+    if (index == 0)
+      return this.props.renderAddNewHeader()
 
     return (
       <SelectedIndicatorItem indicator={item} key={index}
@@ -71,10 +74,10 @@ class IndicatorDevelopmentList extends Component {
   }
 
   renderScrollView() {
-    const selectedIndicators = this.state.selectedIndicators.filter(indicator => indicator.scorecard_uuid == this.props.scorecardUuid);
+    const selectedIndicators = [{item: 'header'}, ...this.state.selectedIndicators.filter(indicator => indicator.scorecard_uuid == this.props.scorecardUuid)];
     const containerPaddingTop = this.scrollY.interpolate({
       inputRange: [0, 100, 140],
-      outputRange: [156, 60, 58],
+      outputRange: [156, 80, 70],
       extrapolate: 'clamp',
     })
     return <Animated.View style={{flex: 1, paddingTop: containerPaddingTop}}>
@@ -84,9 +87,9 @@ class IndicatorDevelopmentList extends Component {
                 keyExtractor={(item, index) => index.toString()}
                 renderItem={(params) => this.renderItem(params)}
                 containerStyle={{marginHorizontal: -4, paddingHorizontal: containerPadding}}
-                ListHeaderComponent={this.props.renderHeader()}
+                ListHeaderComponent={<Tip screenName='IndicatorDevelopment' showTipModal={() => this.props.tipModalRef.current?.present()} containerStyle={{marginTop: containerPadding}} />}
                 onScrollOffsetChange={(offset) => this.onListScroll(offset)}
-                stickyHeaderIndices={[0]}
+                stickyHeaderIndices={[1]}
               />
            </Animated.View>
   }

--- a/app/components/Participant/ParticipantMain.js
+++ b/app/components/Participant/ParticipantMain.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Animated, ScrollView } from 'react-native';
+import { Animated, ScrollView, View } from 'react-native';
 
 import {LocalizationContext} from '../Translations';
 import ParticipantHeader from './ParticipantHeader';
@@ -72,7 +72,7 @@ class ParticipantMain extends React.Component {
     })
 
     return (
-      <React.Fragment>
+      <View style={{flexGrow: 1}}>
         <CollapsibleNavHeader title={this.context.translations.getStarted} progressIndex={2}  scrollY={this.scrollY} tipIconVisible={false} />
         <Animated.View style={{flex: 1, paddingTop: containerPaddingTop}}>
           <ScrollView contentContainerStyle={{flexGrow: 1}}
@@ -85,7 +85,7 @@ class ParticipantMain extends React.Component {
             { this.props.participants.length == 0 && this.renderNoData() }
           </ScrollView>
         </Animated.View>
-      </React.Fragment>
+      </View>
     )
   }
 }

--- a/app/components/ProposedIndicator/ProposedIndicatorMain.js
+++ b/app/components/ProposedIndicator/ProposedIndicatorMain.js
@@ -69,12 +69,12 @@ class ProposedIndicatorContent extends Component {
   render() {
     const containerPaddingTop = this.scrollY.interpolate({
       inputRange: [0, 100, 140],
-      outputRange: [156, 80, 66],
+      outputRange: [156, 80, 70],
       extrapolate: 'clamp',
     })
 
     return (
-      <View style={{flexGrow: 1}}>
+      <React.Fragment>
         <CollapsibleNavHeader title={this.context.translations.proposeTheIndicator} scrollY={this.scrollY} progressIndex={3}
           showTipModal={() => !!this.isHeaderShrunk && this.props.tipModalRef.current?.present()} tipIconVisible={true}
         />
@@ -100,7 +100,7 @@ class ProposedIndicatorContent extends Component {
 
           { this.renderFinishButton() }
         </Animated.View>
-      </View>
+      </React.Fragment>
     );
   }
 }

--- a/app/styles/tablet/ProposedIndicatorComponentStyle.js
+++ b/app/styles/tablet/ProposedIndicatorComponentStyle.js
@@ -11,10 +11,9 @@ const ProposedIndicatorComponentStyles = StyleSheet.create({
     backgroundColor: Color.defaultBgColor,
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginBottom: 6,
-    paddingBottom: 14,
+    paddingBottom: containerPadding,
     paddingTop: 4,
-    paddingHorizontal: containerPadding
+    paddingHorizontal: containerPadding,
   },
   headingTitle: {
     fontSize: titleFontSize(),


### PR DESCRIPTION
This pull request fixes the UI and style when the navigation header collapsed in the below screens:
- Participant and proposed indicator screen: fix padding of the sticky content when the header collapsed
- Indicator development screen: allow only the add new button to be sticky when scrolling