### PR TITLE
Prevent the app show duplicate splash screen on Android 12 or higher

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,7 +4,7 @@
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:textColor">#000000</item>
-        <item name="android:windowIsTranslucent">false</item>
+        <item name="android:windowIsTranslucent">true</item>
         <item name="android:editTextBackground">@android:color/transparent</item>
     </style>
 


### PR DESCRIPTION
This pull request prevents the app from showing a duplicate splash screen when launching the app on Android 12 or higher.