### PR TITLE
FIx the data shown incorrectly in scorecard detail when the scorecard…

### DIFF
--- a/app/components/ScorecardDetail/DisplayScorecardInfo.js
+++ b/app/components/ScorecardDetail/DisplayScorecardInfo.js
@@ -21,14 +21,9 @@ class DisplayScorecardInfo extends Component {
       {label: 'province', fieldName: 'province', isObject: false},
       {label: 'district', fieldName: 'district', isObject: false},
       {label: 'commune', fieldName: 'commune', isObject: false},
-      {label: 'factory', fieldName: 'dataset', isObject: true},
+      {label: 'facilityName', fieldName: 'dataset', isObject: true},
       {label: 'implementer', fieldName: 'local_ngo_name', isObject: false},
     ];
-
-    if (scorecardDetail.primary_school != null) {
-      const primarySchool = { label: 'primarySchool', fieldName: 'primary_school', isObject: true };
-      renderFields.splice(6, 0, primarySchool);
-    }
 
     return renderFields.map((renderField, index) => {
       let value = scorecardDetail[renderField.fieldName] != undefined ? scorecardDetail[renderField.fieldName].toString() : ''
@@ -42,7 +37,7 @@ class DisplayScorecardInfo extends Component {
 
       return (
         <TextInput
-          label={translations[renderField.label]}
+          label={ renderField.label != 'facilityName' ? translations[renderField.label] : this.getFieldValueByLanguage(scorecardDetail.facility, appLanguage)}
           mode="outlined"
           value={value}
           editable={false}


### PR DESCRIPTION
This pull request fixes the issue of the data showing incorrectly in the scorecard detail screen when the scorecard type is health center or high school.

Below is the screenshot of the scorecard detail of the different types of the scorecard:
[scorecard detail.zip](https://github.com/ilabsea/scorecard_mobile/files/11447699/scorecard.detail.zip)
