### PR TITLE
Adjust padding bottom of participant bottom sheet

### DIFF
--- a/app/components/FormBottomSheetModal/FormBottomSheetButton.js
+++ b/app/components/FormBottomSheetModal/FormBottomSheetButton.js
@@ -11,7 +11,7 @@ const FormBottomSheetButton = (props) => {
   const { translations } = useContext(LocalizationContext);
 
   return (
-    <View style={[styles.btnWrapper, { marginHorizontal: containerPadding, marginBottom: 10}, props.wrapperStyle]}>
+    <View style={[styles.btnWrapper, { marginHorizontal: containerPadding, marginBottom: 14}, props.wrapperStyle]}>
       <SaveButton
         disabled={!props.isValid}
         onPress={() => props.save()}

--- a/app/components/FormBottomSheetModal/FormBottomSheetButton.js
+++ b/app/components/FormBottomSheetModal/FormBottomSheetButton.js
@@ -11,7 +11,7 @@ const FormBottomSheetButton = (props) => {
   const { translations } = useContext(LocalizationContext);
 
   return (
-    <View style={[styles.btnWrapper, { marginHorizontal: containerPadding, marginBottom: 16}, props.wrapperStyle]}>
+    <View style={[styles.btnWrapper, { marginHorizontal: containerPadding, marginBottom: 10}, props.wrapperStyle]}>
       <SaveButton
         disabled={!props.isValid}
         onPress={() => props.save()}

--- a/app/components/OutlinedButton.js
+++ b/app/components/OutlinedButton.js
@@ -27,9 +27,11 @@ class OutlinedButton extends Component {
         iconLeft
         style={[{padding: 0, height: pressableItemSize()}, this.props.buttonStyle]}
       >
-        <Icon name={this.props.icon || 'plus'} type="FontAwesome"
-          style={[responsiveStyles.buttonIcon, {color: Color.headerColor, fontSize: this.props.iconFontSize || outlinedButtonIconSize()}, this.props.buttonColor, this.props.iconStyle]}
-        />
+        { !this.props.hideIcon &&
+          <Icon name={this.props.icon || 'plus'} type="FontAwesome"
+            style={[responsiveStyles.buttonIcon, {color: Color.headerColor, fontSize: this.props.iconFontSize || outlinedButtonIconSize()}, this.props.buttonColor, this.props.iconStyle]}
+          />
+        }
         { !!this.props.subLabel ? this.renderlabelAndSubLabel()
           : <Text style={[{color: Color.headerColor}, responsiveStyles.buttonLabel, this.props.buttonColor, this.props.labelStyle]}>{this.props.label}</Text>
         }

--- a/app/components/ProposeNewIndicator/ProposeNewIndicatorAddNewButton.js
+++ b/app/components/ProposeNewIndicator/ProposeNewIndicatorAddNewButton.js
@@ -22,7 +22,7 @@ class ProposedNewIndicatorAddNewButton extends React.Component {
   render() {
     return <OutlinedButton
               label={this.context.translations.createNewIndicator}
-              buttonStyle={{marginBottom: getDeviceStyle(20, 16), marginHorizontal: 16, height: getDeviceStyle(72, 62), borderRadius: 8, borderWidth: 2}}
+              buttonStyle={{marginBottom: getDeviceStyle(20, 16), marginHorizontal: 16, height: getDeviceStyle(72, 62)}}
               iconFontSize={getDeviceStyle(38, 32)}
               labelStyle={{textAlign: 'center', fontSize: getDeviceStyle(18, 16), marginTop: getDeviceStyle(6, 4)}}
               subLabel={`(${this.props.searchedText})`}

--- a/app/components/ProposeNewIndicator/ProposeNewIndicatorSearchBox.js
+++ b/app/components/ProposeNewIndicator/ProposeNewIndicatorSearchBox.js
@@ -136,7 +136,7 @@ class ProposeNewIndicatorSearchBox extends React.Component {
                   inputContainerStyle={{backgroundColor: Color.whiteColor, marginTop: -5, marginLeft: -1}}
                   placeholder={translations.theIndicatorNameYouWantToPropose}
                   onChangeText={(text) => this.onChangeText(text)}
-                  onClearSearch={() => this.setState({searchedText: ''})}
+                  onClearSearch={() => this.onChangeText('')}
                   onFocus={() => this.onFocus()}
                   onBlur={() => this.setState({isSearchFocused: false})}
                 />

--- a/app/components/ProposeNewIndicator/ProposeNewIndicatorSearchResult.js
+++ b/app/components/ProposeNewIndicator/ProposeNewIndicatorSearchResult.js
@@ -5,12 +5,14 @@ import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-nativ
 import {LocalizationContext} from '../Translations';
 import ProposeNewIndicatorSearchResultCardList from './ProposeNewIndicatorSearchResultCardList';
 import ProposeNewIndicatorAddNewButton from './ProposeNewIndicatorAddNewButton';
+import OutlinedButton from '../OutlinedButton';
 import settingHelper from '../../helpers/setting_helper';
 import proposedIndicatorHelper from '../../helpers/proposed_indicator_helper';
 import proposedIndicatorStyleHelper from '../../helpers/proposed_indicator_style_helper';
 import proposedIndicatorService from '../../services/proposed_indicator_service';
 import Indicator from '../../models/Indicator';
 import {participantModalSnapPoints} from '../../constants/modal_constant';
+import { getDeviceStyle } from '../../utils/responsive_util';
 
 class ProposeNewIndicatorSearchResult extends React.Component {
   static contextType = LocalizationContext;
@@ -50,6 +52,16 @@ class ProposeNewIndicatorSearchResult extends React.Component {
            </ScrollView>
   }
 
+  renderSaveBtn = () => {
+    return <OutlinedButton
+              label={this.context.translations.confirmAndSave}
+              buttonStyle={{marginBottom: getDeviceStyle(20, 16), marginHorizontal: 16, height: 56}}
+              labelStyle={{textAlign: 'center', fontSize: getDeviceStyle(18, 16), paddingLeft: 0, flex: 1}}
+              hideIcon={true}
+              onPress={() => this.props.closeSearch()}
+           />
+  }
+
   render() {
     return (
       <React.Fragment>
@@ -60,6 +72,7 @@ class ProposeNewIndicatorSearchResult extends React.Component {
               startProposeIndicator={(customIndicator) => this.startProposeIndicator(customIndicator, true)}
             />
           }
+          {!this.props.isIndicatorBase && this.renderSaveBtn()}
         </View>
         <TouchableWithoutFeedback onPress={() => this.props.closeSearch()}>
           <View style={{position: 'absolute', height: hp('100%'), width: wp('100%'), zIndex: -1}} />

--- a/app/components/ProposeNewIndicator/ProposeNewIndicatorSearchResult.js
+++ b/app/components/ProposeNewIndicator/ProposeNewIndicatorSearchResult.js
@@ -24,6 +24,8 @@ class ProposeNewIndicatorSearchResult extends React.Component {
       const duplicatedIndicators = Indicator.findByScorecardAndName(this.props.scorecardUuid, this.props.searchedText, endpointId);
       this.setState({showAddNewButton: duplicatedIndicators.length > 0 ? false : true})
     }
+    else if (!this.props.searchedText)
+      this.setState({showAddNewButton: false})
   }
 
   startProposeIndicator = (indicator, isNewCustomIndicator) => {
@@ -72,7 +74,7 @@ class ProposeNewIndicatorSearchResult extends React.Component {
               startProposeIndicator={(customIndicator) => this.startProposeIndicator(customIndicator, true)}
             />
           }
-          {!this.props.isIndicatorBase && this.renderSaveBtn()}
+          {(!this.props.isIndicatorBase && !this.state.showAddNewButton) && this.renderSaveBtn()}
         </View>
         <TouchableWithoutFeedback onPress={() => this.props.closeSearch()}>
           <View style={{position: 'absolute', height: hp('100%'), width: wp('100%'), zIndex: -1}} />

--- a/app/screens/ProposeNewIndicator/ProposeNewIndicator.js
+++ b/app/screens/ProposeNewIndicator/ProposeNewIndicator.js
@@ -129,7 +129,7 @@ class ProposeNewIndicator extends React.Component {
 
   renderBody = () => {
     const {translations} = this.context
-    return <View style={{flexGrow: 1, paddingHorizontal: containerPadding, paddingTop: 15}}>
+    return <View style={{flexGrow: 1, paddingHorizontal: containerPadding, paddingTop: 15, backgroundColor: Color.defaultBgColor}}>
               {this.renderSearchBox()}
               <View style={{flex: 1}}>
                 {this.renderProposedIndicators()}


### PR DESCRIPTION
This pull request adjusts the margin-bottom of the bottom sheet button and adds a "Save" button to the indicator search result of the proposed indicator screen when the proposed indicator type is participant based.

Below are the screenshots of the indicator search result and the bottom sheet:
[participant based button.zip](https://github.com/ilabsea/scorecard_mobile/files/11504244/participant.based.button.zip)
