### PR TITLE
Fix scorecard list style break when scorecard type is health center

### DIFF
--- a/app/components/ScorecardList/ScorecardListInfoDetail.js
+++ b/app/components/ScorecardList/ScorecardListInfoDetail.js
@@ -9,9 +9,8 @@ import EndpointBadge from '../Share/EndpointBadge';
 import VotingIndicator from '../../models/VotingIndicator';
 import scorecardHelper from '../../helpers/scorecard_helper';
 import { getDeviceStyle } from '../../utils/responsive_util';
+import { getMobileFontSizeByPixelRatio } from '../../utils/font_size_util';
 import { scorecardListSubTitleMobileFontSize } from '../../constants/scorecard_constant';
-
-const subTextFontSize = getDeviceStyle(13, scorecardListSubTitleMobileFontSize);
 
 class ScorecardListInfoDetail extends Component {
   static contextType = LocalizationContext;
@@ -21,7 +20,7 @@ class ScorecardListInfoDetail extends Component {
 
     if (scorecard.conducted_date)
       return (
-        <Text style={{ flex: 1, textAlign: 'right', color: Color.grayColor, fontSize: subTextFontSize, marginTop: getDeviceStyle(2, 4)}}>
+        <Text style={{ flex: 1, textAlign: 'right', color: Color.lightGrayColor, fontSize: getDeviceStyle(13, getMobileFontSizeByPixelRatio(11.5, 11.5)), marginTop: getDeviceStyle(2, 4)}}>
           { !!scorecard.conducted_date ? scorecardHelper.getTranslatedDate(scorecard.conducted_date, this.context.appLanguage, 'DD MMM') : '' }
         </Text>
       )
@@ -36,14 +35,14 @@ class ScorecardListInfoDetail extends Component {
   render() {
     const { scorecard } = this.props;
     const indicatorsSize = VotingIndicator.getAll(scorecard.uuid).length;
-    const subTextStyles = { paddingTop: getDeviceStyle(2, 1), fontSize: subTextFontSize, marginLeft: 0};
+    const subTextStyles = { paddingTop: getDeviceStyle(2, 1), fontSize: getDeviceStyle(13, scorecardListSubTitleMobileFontSize), marginLeft: 0};
     const subTitleMarginTop = getDeviceStyle(2, 3);
 
     return (
       <View style={{flexDirection: 'row'}}>
         <Text style={[styles.subText, subTextStyles, {marginTop: subTitleMarginTop, color: Color.grayColor}]}>{ scorecard.facility_code }: </Text>
         <Text style={[{fontSize: getDeviceStyle(16, 15), marginTop: 0}]}>{ scorecard.uuid } </Text>
-        <Text style={[styles.subText, subTextStyles, {marginTop: subTitleMarginTop, color: Color.grayColor}]}>
+        <Text style={[styles.subText, subTextStyles, {marginTop: subTitleMarginTop, color: Color.lightGrayColor}]}>
           ({this.context.translations.raisedIndicator}: {indicatorsSize})
         </Text>
 

--- a/app/components/ScorecardList/ScorecardListInfoLocation.js
+++ b/app/components/ScorecardList/ScorecardListInfoLocation.js
@@ -35,7 +35,7 @@ class ScorecardListInfoLocation extends Component {
 
     return (
       <View style={{flex: 1, flexDirection: 'row', paddingRight: 10, alignItems: 'center', marginTop: getDeviceStyle(-4, 0)}}>
-        <AppIcon name='map-marker' size={14} color={Color.grayColor} style={{marginRight: 5, marginTop: getDeviceStyle(-3, -4)}} />
+        <AppIcon name='map-marker' size={14} color={Color.lightGrayColor} style={{marginRight: 5, marginTop: getDeviceStyle(-3, -4)}} />
         <View style={{flex: 3, flexDirection: 'row'}}>
           { scorecard.primary_school && this.renderPrimarySchool(scorecard) }
 

--- a/app/components/ScorecardList/ScorecardListInfoLocation.js
+++ b/app/components/ScorecardList/ScorecardListInfoLocation.js
@@ -16,15 +16,6 @@ const responsiveStyles = getDeviceStyle(ScorecardItemTabletStyles, ScorecardItem
 
 class ScorecardListInfoLocation extends Component {
   static contextType = LocalizationContext;
-
-  renderPrimarySchool() {
-    return (
-      <Text style={responsiveStyles.locationLabel}>
-        { JSON.parse(this.props.scorecard.primary_school)[`name_${this.context.appLanguage}`] }
-      </Text>
-    )
-  }
-
   renderCommune() {
     return !!this.props.scorecard.commune ? `${this.props.scorecard.commune}, ` : '';
   }
@@ -32,15 +23,14 @@ class ScorecardListInfoLocation extends Component {
   renderScorecardLocation() {
     const { scorecard } = this.props;
     const {appLanguage} = this.context;
+    const facilityLabel = scorecardHelper.getFacilityLabel(scorecard, appLanguage, true)
 
     return (
       <View style={{flex: 1, flexDirection: 'row', paddingRight: 10, alignItems: 'center', marginTop: getDeviceStyle(-4, 0)}}>
         <AppIcon name='map-marker' size={14} color={Color.lightGrayColor} style={{marginRight: 5, marginTop: getDeviceStyle(-3, -4)}} />
         <View style={{flex: 3, flexDirection: 'row'}}>
-          { scorecard.primary_school && this.renderPrimarySchool(scorecard) }
-
           <Text numberOfLines={1} style={[responsiveStyles.locationLabel, { maxWidth: getLocationMaxWidth(scorecard, appLanguage)}]}>
-            { this.props.scorecard.primary_school && `, `}{ scorecardHelper.getFactoryLabel(scorecard, appLanguage) }{ this.renderCommune() }{ scorecard.district }
+            { facilityLabel && `${facilityLabel}, ` }{ this.renderCommune() }{ scorecard.district }
           </Text>
           <Text style={responsiveStyles.locationLabel}>, {scorecard.province}</Text>
         </View>

--- a/app/components/ScorecardProgress/ScorecardProgressTitle.js
+++ b/app/components/ScorecardProgress/ScorecardProgressTitle.js
@@ -18,11 +18,8 @@ class ScorecardProgressTitle extends Component {
 
   renderScorecardLocation() {
     const {appLanguage} = this.context;
-    const language = `name_${appLanguage}`;
-    const primarySchool = this.props.scorecard.primary_school ? `${JSON.parse(this.props.scorecard.primary_school)[language]}, ` : '';
     const commune = this.props.scorecard.commune ? `${this.props.scorecard.commune}, ` : '';
-
-    return `${primarySchool}${scorecardHelper.getFactoryLabel(this.props.scorecard, appLanguage)}${commune}${this.props.scorecard.district}, ${this.props.scorecard.province}`;
+    return `${scorecardHelper.getFacilityLabel(this.props.scorecard, appLanguage, false)}${commune}${this.props.scorecard.district}, ${this.props.scorecard.province}`;
   }
 
   renderConductedDate() {

--- a/app/components/Share/EndpointBadge.js
+++ b/app/components/Share/EndpointBadge.js
@@ -24,7 +24,7 @@ const styles = StyleSheet.create({
     height: 20
   },
   badgeLabel: {
-    fontSize: isShortWidthScreen() ? 10 : 11,
+    fontSize: isShortWidthScreen() ? 9 : 10,
     textTransform: 'uppercase'
   }
 });

--- a/app/helpers/scorecard_helper.js
+++ b/app/helpers/scorecard_helper.js
@@ -23,7 +23,7 @@ const scorecardHelper = (() => {
     getTranslatedDate,
     updateFinishedMilestone,
     getEndpointUrl,
-    getFactoryLabel,
+    getFacilityLabel,
   };
 
   function isScorecardAvailable(scorecard) {
@@ -124,8 +124,10 @@ const scorecardHelper = (() => {
     return EndpointUrl.findByUrlValue(endpoint);
   }
 
-  function getFactoryLabel(scorecard, language) {
+  function getFacilityLabel(scorecard, language, hideFacility) {
     if (!!scorecard.dataset) {
+      if (hideFacility) return JSON.parse(scorecard.dataset)[`name_${language}`]
+
       const facility = JSON.parse(scorecard.facility)[`name_${language}`];
       let factory = `${JSON.parse(scorecard.dataset)[`name_${language}`]}`
       factory = language == 'km' ? `${facility} ${factory}, ` : `${factory} ${facility}, `;

--- a/app/styles/mobile/ScorecardItemComponentStyle.js
+++ b/app/styles/mobile/ScorecardItemComponentStyle.js
@@ -63,7 +63,7 @@ const ScorecardItemComponentStyles = StyleSheet.create({
   locationLabel: {
     fontSize: scorecardListSubTitleMobileFontSize,
     marginLeft: 4,
-    color: Color.grayColor,
+    color: Color.lightGrayColor,
     marginRight: 0,
     marginLeft: 0,
     fontFamily: FontFamily.body,

--- a/app/styles/tablet/ScorecardItemComponentStyle.js
+++ b/app/styles/tablet/ScorecardItemComponentStyle.js
@@ -55,7 +55,7 @@ const ScorecardItemComponentStyles = StyleSheet.create({
   locationLabel: {
     fontSize: 14,
     marginLeft: 4,
-    color: Color.grayColor,
+    color: Color.lightGrayColor,
     marginRight: 0,
     marginLeft: 0,
     fontFamily: FontFamily.body,

--- a/app/utils/scorecard_util.js
+++ b/app/utils/scorecard_util.js
@@ -34,7 +34,7 @@ export const getLocationMaxWidth = (scorecard, language) => {
 
   // If the width of  primary school + province very long then the district and commun will not show in the list item
   if (isShortWidthScreen() && mainLocationWidth >= wp('42%'))
-    return 0;
+    return wp('23%')
 
   locationWidth = locationWidth * pixelPerCharacter;
   const locationLength = factoryLength > 0 ? scorecard.district.length + getDeviceStyle(0, 10) : scorecard.commune.length + 2;            // +2 because district and commune are include , and 1 space
@@ -48,8 +48,8 @@ export const getLocationMaxWidth = (scorecard, language) => {
 
     return locationLength * (scorecard.primary_school != null ? locationPixel[language] : locationPixel.default);
   }
-
-  return getDeviceStyle(locationLength * wp('3.8%'), locationLength * wp('1.4%'))
+  const mobilePixel = isShortWidthScreen() ? wp('2.5%') : wp('3%')
+  return getDeviceStyle(locationLength * wp('6.3%'), locationLength * mobilePixel)
 }
 
 export const handleScorecardCodeClipboard = async (updateErrorState) => {


### PR DESCRIPTION
This pull request updates and fixes the style break of the scorecard list screen when the scorecard type is health center (on a mobile device):
- Decrease the font size of the conducted date (on mobile only)
- Decrease the font size of the label on the badge
- Update the color of the subtitle of the scorecard list to a light gray color to make it consistent with the subtitle of the proposed indicator
- Fix the display of the scorecard location in the card item of the scorecard list

Below are the updated screenshots on mobile and tablet devices:
[scorecard list.zip](https://github.com/ilabsea/scorecard_mobile/files/11506877/scorecard.list.zip)
